### PR TITLE
[#23] Implement built-in event type modules

### DIFF
--- a/backend/src/event-types/BitsEventType.js
+++ b/backend/src/event-types/BitsEventType.js
@@ -1,0 +1,21 @@
+import { BaseEventType } from './BaseEventType.js';
+
+export class BitsEventType extends BaseEventType {
+
+    get type() { return 'bits'; }
+
+    match(rawEvent, config) {
+        return rawEvent.subscriptionType === 'channel.cheer'
+            && config.event_type === this.type;
+    }
+
+    extractTemplateData(rawEvent) {
+        const { event } = rawEvent;
+        return {
+            username: event.is_anonymous ? 'Anonymous' : event.user_name,
+            display_name: event.is_anonymous ? 'Anonymous' : event.user_name,
+            user_id: event.user_id ?? '',
+            count: String(event.bits)
+        };
+    }
+}

--- a/backend/src/event-types/ChannelPointsRedemptionEventType.js
+++ b/backend/src/event-types/ChannelPointsRedemptionEventType.js
@@ -1,0 +1,25 @@
+import { BaseEventType } from './BaseEventType.js';
+
+const SUBSCRIPTION_TYPE = 'channel.channel_points_custom_reward_redemption.add';
+
+export class ChannelPointsRedemptionEventType extends BaseEventType {
+
+    get type() { return 'channel_points_redemption'; }
+
+    match(rawEvent, config) {
+        if (rawEvent.subscriptionType !== SUBSCRIPTION_TYPE) return false;
+        if (config.event_type !== this.type) return false;
+        return (config.trigger_on ?? []).includes(rawEvent.event.reward.title);
+    }
+
+    extractTemplateData(rawEvent) {
+        const { event } = rawEvent;
+        return {
+            username: event.user_name,
+            display_name: event.user_name,
+            user_id: event.user_id,
+            reward: event.reward.title,
+            user_input: event.user_input ?? ''
+        };
+    }
+}

--- a/backend/src/event-types/ChatCommandEventType.js
+++ b/backend/src/event-types/ChatCommandEventType.js
@@ -1,0 +1,28 @@
+import { BaseEventType } from './BaseEventType.js';
+
+export class ChatCommandEventType extends BaseEventType {
+
+    get type() { return 'chat_command'; }
+
+    match(rawEvent, config) {
+        if (rawEvent.subscriptionType !== 'channel.chat.message') return false;
+        if (config.event_type !== this.type) return false;
+        const command = this.#parseCommand(rawEvent.event.message.text);
+        return command !== null && (config.trigger_on ?? []).includes(command);
+    }
+
+    extractTemplateData(rawEvent) {
+        const { event } = rawEvent;
+        return {
+            username: event.chatter_user_name,
+            display_name: event.chatter_user_display_name,
+            user_id: event.chatter_user_id
+        };
+    }
+
+    /** @returns {string|null} Command name without the leading '!', or null if not a command */
+    #parseCommand(text) {
+        if (!text?.startsWith('!')) return null;
+        return text.substring(1).split(' ')[0].toLowerCase();
+    }
+}

--- a/backend/src/event-types/FollowEventType.js
+++ b/backend/src/event-types/FollowEventType.js
@@ -1,0 +1,21 @@
+import { BaseEventType } from './BaseEventType.js';
+
+export class FollowEventType extends BaseEventType {
+
+    get type() { return 'follow'; }
+
+    match(rawEvent, config) {
+        return rawEvent.subscriptionType === 'channel.follow'
+            && config.event_type === this.type;
+    }
+
+    extractTemplateData(rawEvent) {
+        const { event } = rawEvent;
+        return {
+            username: event.user_name,
+            display_name: event.user_display_name,
+            user_id: event.user_id,
+            followed_at: event.followed_at
+        };
+    }
+}

--- a/backend/src/event-types/RaidEventType.js
+++ b/backend/src/event-types/RaidEventType.js
@@ -1,0 +1,21 @@
+import { BaseEventType } from './BaseEventType.js';
+
+export class RaidEventType extends BaseEventType {
+
+    get type() { return 'raid'; }
+
+    match(rawEvent, config) {
+        return rawEvent.subscriptionType === 'channel.raid'
+            && config.event_type === this.type;
+    }
+
+    extractTemplateData(rawEvent) {
+        const { event } = rawEvent;
+        return {
+            username: event.from_broadcaster_user_name,
+            display_name: event.from_broadcaster_user_name,
+            user_id: event.from_broadcaster_user_id,
+            count: String(event.viewers)
+        };
+    }
+}

--- a/backend/src/event-types/SubscriptionEventType.js
+++ b/backend/src/event-types/SubscriptionEventType.js
@@ -1,0 +1,21 @@
+import { BaseEventType } from './BaseEventType.js';
+
+export class SubscriptionEventType extends BaseEventType {
+
+    get type() { return 'subscription'; }
+
+    match(rawEvent, config) {
+        return rawEvent.subscriptionType === 'channel.subscribe'
+            && config.event_type === this.type;
+    }
+
+    extractTemplateData(rawEvent) {
+        const { event } = rawEvent;
+        return {
+            username: event.user_name,
+            display_name: event.user_name,
+            user_id: event.user_id,
+            tier: event.tier
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 6 event type modules to `backend/src/event-types/`, each extending `BaseEventType`
- All modules receive `rawEvent = { subscriptionType, event }` mirroring the Twitch EventSub payload structure

| Module | `event_type` | Twitch subscription |
|---|---|---|
| `ChatCommandEventType` | `chat_command` | `channel.chat.message` |
| `FollowEventType` | `follow` | `channel.follow` |
| `SubscriptionEventType` | `subscription` | `channel.subscribe` |
| `RaidEventType` | `raid` | `channel.raid` |
| `BitsEventType` | `bits` | `channel.cheer` |
| `ChannelPointsRedemptionEventType` | `channel_points_redemption` | `channel.channel_points_custom_reward_redemption.add` |

## Notes
- `BitsEventType` handles anonymous cheers (username falls back to `'Anonymous'`)
- `ChannelPointsRedemptionEventType` matches by reward **title** (not ID) via `trigger_on`
- `rawEvent` shape is the contract EventRouter (#24) must conform to

Closes #23

🤖 Generated with [Claude Code](https://claude.ai/code)