### PR TITLE
[#53] Dual token architecture: separate WebSocket sessions for bot and broadcaster

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -3,33 +3,42 @@ import 'dotenv/config';
 
 const CLIENT_ID = process.env.TWITCH_CLIENT_ID;
 const REDIRECT_URI = 'http://localhost';
-const SCOPES = [
-    'user:read:chat',
-    'user:write:chat',
-    'channel:read:subscriptions',
-    'moderator:read:followers',
-    'moderator:read:chatters',
-    'channel:read:redemptions',
-    'bits:read',
-];
+
+const SCOPES = {
+    bot: [
+        'user:read:chat',
+        'user:write:chat',
+        'moderator:read:followers',
+        'moderator:read:chatters',
+    ],
+    streamer: [
+        'channel:read:subscriptions',
+        'channel:read:redemptions',
+        'bits:read',
+    ],
+};
+
+const mode = process.argv[2] as 'bot' | 'streamer' | undefined;
 
 if (!CLIENT_ID) {
     console.error('TWITCH_CLIENT_ID is not set in .env — cannot build authorization URL.');
     process.exit(1);
 }
 
-export function buildAuthUrl(clientId: string): string {
-    const url = new URL('https://id.twitch.tv/oauth2/authorize');
-    url.searchParams.set('client_id', clientId);
-    url.searchParams.set('redirect_uri', REDIRECT_URI);
-    url.searchParams.set('response_type', 'token');
-    url.searchParams.set('scope', SCOPES.join(' '));
-    return url.toString();
+if (!mode || !(mode in SCOPES)) {
+    console.error('Usage: npm run auth:bot  OR  npm run auth:streamer');
+    process.exit(1);
 }
 
-const authUrl = buildAuthUrl(CLIENT_ID);
+const url = new URL('https://id.twitch.tv/oauth2/authorize');
+url.searchParams.set('client_id', CLIENT_ID);
+url.searchParams.set('redirect_uri', REDIRECT_URI);
+url.searchParams.set('response_type', 'token');
+url.searchParams.set('scope', SCOPES[mode].join(' '));
 
-console.log('\n1. Click this link to authorize with Twitch:\n');
-console.log('   ' + authUrl);
-console.log('\n2. After authorizing, copy the access_token value from the redirect URL.');
-console.log('3. Paste it into your .env as TWITCH_ACCESS_TOKEN.\n');
+const envVar = mode === 'bot' ? 'TWITCH_ACCESS_TOKEN' : 'TWITCH_BROADCASTER_TOKEN';
+
+console.log(`\n1. Log into Twitch as your ${mode} account, then open this link:\n`);
+console.log('   ' + url.toString());
+console.log(`\n2. After authorizing, copy the access_token from the redirect URL.`);
+console.log(`3. Paste it into your .env as ${envVar}.\n`);

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,9 +6,14 @@
 TWITCH_CLIENT_ID=your_client_id_here
 
 # Required: OAuth access token for your bot account
-# Generate this using the Twitch CLI or OAuth flow
-# Required scopes: user:read:chat, user:write:chat, channel:read:subscriptions, moderator:read:followers, moderator:read:chatters, channel:read:redemptions, bits:read
-TWITCH_ACCESS_TOKEN=your_access_token_here
+# Required scopes: user:read:chat, user:write:chat, moderator:read:followers, moderator:read:chatters
+TWITCH_ACCESS_TOKEN=your_bot_access_token_here
+
+# Optional: OAuth access token for the broadcaster account
+# Required when the bot and broadcaster are different accounts
+# Required scopes: channel:read:subscriptions, channel:read:redemptions, bits:read
+# If omitted, TWITCH_ACCESS_TOKEN is used for all subscriptions (single-account mode)
+TWITCH_BROADCASTER_TOKEN=your_broadcaster_access_token_here
 
 # Optional: Target channel name (if different from bot account)
 # If not specified, will use the bot's own channel

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -24,6 +24,7 @@ try {
 
         twitchClient = new TwitchClient({
             accessToken: process.env.TWITCH_ACCESS_TOKEN,
+            broadcasterToken: process.env.TWITCH_BROADCASTER_TOKEN,
             clientId: process.env.TWITCH_CLIENT_ID,
             channelName: process.env.TWITCH_CHANNEL_NAME,
             overlayBroadcasterService,

--- a/backend/src/EventRouter.ts
+++ b/backend/src/EventRouter.ts
@@ -33,14 +33,20 @@ export class EventRouter extends Handler {
     }
 
     async route(rawEvent: TwitchRawEvent): Promise<void> {
-        Logger.log('EventRouter: Received event:', rawEvent);
+        Logger.info(`EventRouter: Routing "${rawEvent.subscriptionType}"`);
+        let matched = false;
         for (const eventType of this.eventTypes) {
             for (const config of this.configs) {
                 if (eventType.match(rawEvent, config)) {
+                    Logger.info(`EventRouter: Matched [${eventType.type}] → "${config.event_name}"`);
                     const templateData: TemplateData = eventType.extractTemplateData(rawEvent);
                     await this.executeConfig(config, templateData);
+                    matched = true;
                 }
             }
+        }
+        if (!matched) {
+            Logger.info(`EventRouter: No match for "${rawEvent.subscriptionType}"`);
         }
     }
 

--- a/backend/src/EventSubSession.ts
+++ b/backend/src/EventSubSession.ts
@@ -1,0 +1,94 @@
+import WebSocket from 'ws';
+import Logger from './utils/Logger.js';
+
+interface EventSubMessage {
+    metadata: { message_type: string }
+    payload: {
+        session?: { id: string }
+        subscription?: { type: string }
+        event?: Record<string, unknown>
+    }
+}
+
+export interface EventSubNotification {
+    subscriptionType: string
+    event: Record<string, unknown>
+}
+
+export class EventSubSession {
+    private websocket: WebSocket | null = null;
+    private sessionId: string | null = null;
+    private readonly token: string;
+    private readonly clientId: string;
+    private readonly label: string;
+    private readonly onReady: (sessionId: string) => Promise<void>;
+    private readonly onNotification: (notification: EventSubNotification) => void;
+
+    constructor(
+        token: string,
+        clientId: string,
+        label: string,
+        onReady: (sessionId: string) => Promise<void>,
+        onNotification: (notification: EventSubNotification) => void
+    ) {
+        this.token = token;
+        this.clientId = clientId;
+        this.label = label;
+        this.onReady = onReady;
+        this.onNotification = onNotification;
+    }
+
+    connect(): void {
+        this.websocket = new WebSocket('wss://eventsub.wss.twitch.tv/ws');
+
+        this.websocket.onopen = () => Logger.info(`EventSubSession[${this.label}]: Connected`);
+
+        this.websocket.onmessage = (event) => {
+            const message = JSON.parse(event.data as string) as EventSubMessage;
+            if (message.metadata.message_type === 'session_keepalive') return;
+            this.handleMessage(message);
+        };
+
+        this.websocket.onclose = (event) => {
+            Logger.warn(`EventSubSession[${this.label}]: Closed (${event.code}) — reconnecting in 5s`);
+            setTimeout(() => this.connect(), 5000);
+        };
+
+        this.websocket.onerror = (error) => Logger.error(`EventSubSession[${this.label}]: Error:`, error);
+    }
+
+    private async handleMessage(message: EventSubMessage): Promise<void> {
+        switch (message.metadata.message_type) {
+            case 'session_welcome':
+                this.sessionId = message.payload.session?.id ?? null;
+                Logger.info(`EventSubSession[${this.label}]: Session ready`);
+                if (this.sessionId) await this.onReady(this.sessionId);
+                break;
+
+            case 'notification':
+                this.handleNotification(message);
+                break;
+
+            case 'session_reconnect':
+                Logger.info(`EventSubSession[${this.label}]: Reconnect requested`);
+                break;
+        }
+    }
+
+    private handleNotification(message: EventSubMessage): void {
+        const subType = message.payload.subscription?.type ?? '';
+        const event = message.payload.event ?? {};
+        Logger.info(`EventSubSession[${this.label}]: Notification received:`, { subscriptionType: subType, event });
+        this.onNotification({ subscriptionType: subType, event });
+    }
+
+    getSessionId(): string | null {
+        return this.sessionId;
+    }
+
+    disconnect(): void {
+        this.websocket?.close();
+    }
+}
+
+export default EventSubSession;

--- a/backend/src/base/Handler.ts
+++ b/backend/src/base/Handler.ts
@@ -14,8 +14,17 @@ export class Handler {
     }
 
     async executeConfig(config: EventConfig, templateData: TemplateData): Promise<void> {
-        if (config.reply && this.twitchClient) {
-            await this.twitchClient.sendChatMessage(this.processTemplate(config.reply, templateData));
+        Logger.info(`Handler: Executing "${config.event_name}"`);
+
+        if (config.reply) {
+            if (this.twitchClient) {
+                const message = this.processTemplate(config.reply, templateData);
+                Logger.info(`Handler: Sending chat reply: "${message}"`);
+                const ok = await this.twitchClient.sendChatMessage(message);
+                Logger.info(`Handler: Chat reply ${ok ? 'sent' : 'FAILED'}`);
+            } else {
+                Logger.warn('Handler: Skipping reply — twitchClient not set');
+            }
         }
 
         if (config.image || config.sound || config.text || config.video) {
@@ -33,7 +42,10 @@ export class Handler {
             };
 
             if (this.overlayBroadcasterService) {
+                Logger.info(`Handler: Broadcasting overlay event for "${config.event_name}"`);
                 await this.overlayBroadcasterService.broadcast(overlayEvent);
+            } else {
+                Logger.warn('Handler: Skipping overlay broadcast — overlayBroadcasterService not set');
             }
         }
     }

--- a/backend/src/event-types/ChatCommandEventType.ts
+++ b/backend/src/event-types/ChatCommandEventType.ts
@@ -1,4 +1,5 @@
 import { BaseEventType } from './BaseEventType.js';
+import Logger from '../utils/Logger.js';
 import type { EventConfig, TemplateData, TwitchRawEvent } from '../types.js';
 
 export class ChatCommandEventType extends BaseEventType {
@@ -10,7 +11,10 @@ export class ChatCommandEventType extends BaseEventType {
         if (config.event_type !== this.type) return false;
         const event = rawEvent.event as { message: { text: string } };
         const command = this.#parseCommand(event.message.text);
-        return command !== null && (config.trigger_on ?? []).includes(command);
+        const triggers = config.trigger_on ?? [];
+        const matched = command !== null && triggers.includes(command);
+        Logger.info(`ChatCommand: parsed="${command}" config="${config.event_name}" triggers=[${triggers.join(', ')}] → ${matched ? 'MATCH' : 'no match'}`);
+        return matched;
     }
 
     extractTemplateData(rawEvent: TwitchRawEvent): TemplateData {

--- a/backend/src/twitch-client.ts
+++ b/backend/src/twitch-client.ts
@@ -35,6 +35,7 @@ interface EventSubMessage {
 
 export interface TwitchClientOptions {
     accessToken?: string
+    broadcasterToken?: string
     clientId?: string
     channelName?: string
     overlayBroadcasterService?: IOverlayBroadcaster
@@ -45,6 +46,7 @@ export class TwitchClient {
     private websocket: WebSocket | null;
     private sessionId: string | null;
     private accessToken: string;
+    private broadcasterToken: string;
     private clientId: string;
     private userId: string | null;
     private username: string | null;
@@ -65,6 +67,7 @@ export class TwitchClient {
         }
 
         this.accessToken = accessToken;
+        this.broadcasterToken = options.broadcasterToken ?? process.env.TWITCH_BROADCASTER_TOKEN ?? accessToken;
         this.clientId = clientId;
         this.userId = null;
         this.username = null;
@@ -143,28 +146,48 @@ export class TwitchClient {
     }
 
     private async checkTokenScopes(): Promise<void> {
+        await this.validateScopes(this.accessToken, 'bot', [
+            'user:read:chat',
+            'user:write:chat',
+            'moderator:read:followers',
+            'moderator:read:chatters',
+        ]);
+
+        if (this.broadcasterToken !== this.accessToken) {
+            await this.validateScopes(this.broadcasterToken, 'broadcaster', [
+                'channel:read:subscriptions',
+                'channel:read:redemptions',
+                'bits:read',
+            ]);
+        } else {
+            await this.validateScopes(this.accessToken, 'single-account', [
+                'user:read:chat',
+                'user:write:chat',
+                'moderator:read:followers',
+                'channel:read:subscriptions',
+                'channel:read:redemptions',
+                'bits:read',
+            ]);
+        }
+    }
+
+    private async validateScopes(token: string, label: string, required: string[]): Promise<void> {
         try {
             const response = await fetch('https://id.twitch.tv/oauth2/validate', {
-                headers: { 'Authorization': `Bearer ${this.accessToken}` }
+                headers: { 'Authorization': `Bearer ${token}` }
             });
 
             if (response.ok) {
                 const data = await response.json() as TwitchTokenValidation;
-                const required = [
-                    'user:read:chat',
-                    'user:write:chat',
-                    'channel:read:subscriptions',
-                    'moderator:read:followers',
-                    'moderator:read:chatters',
-                    'channel:read:redemptions'
-                ];
                 const missing = required.filter(s => !data.scopes.includes(s));
                 if (missing.length > 0) {
-                    Logger.warn('TwitchClient: Missing token scopes:', missing);
+                    Logger.warn(`TwitchClient: ${label} token missing scopes:`, missing);
+                } else {
+                    Logger.info(`TwitchClient: ${label} token scopes OK`);
                 }
             }
         } catch (error) {
-            Logger.error('TwitchClient: Error validating token:', error);
+            Logger.error(`TwitchClient: Error validating ${label} token:`, error);
         }
     }
 
@@ -216,28 +239,29 @@ export class TwitchClient {
         });
         await this.subscribe('channel.subscribe', '1', {
             broadcaster_user_id: this.channelId
-        });
+        }, this.broadcasterToken);
         await this.subscribe('channel.raid', '1', {
             to_broadcaster_user_id: this.channelId
         });
         await this.subscribe('channel.cheer', '1', {
             broadcaster_user_id: this.channelId
-        });
+        }, this.broadcasterToken);
         await this.subscribe('channel.channel_points_custom_reward_redemption.add', '1', {
             broadcaster_user_id: this.channelId
-        });
+        }, this.broadcasterToken);
     }
 
     private async subscribe(
         type: string,
         version: string,
-        condition: Record<string, string | null>
+        condition: Record<string, string | null>,
+        token: string = this.accessToken
     ): Promise<void> {
         try {
             const response = await fetch('https://api.twitch.tv/helix/eventsub/subscriptions', {
                 method: 'POST',
                 headers: {
-                    'Authorization': `Bearer ${this.accessToken}`,
+                    'Authorization': `Bearer ${token}`,
                     'Client-Id': this.clientId,
                     'Content-Type': 'application/json'
                 },
@@ -266,19 +290,23 @@ export class TwitchClient {
         const subType = message.payload.subscription?.type;
         const event = message.payload.event;
 
-        Logger.debug('TwitchClient: Raw event received:', { subscriptionType: subType, event });
+        Logger.info('TwitchClient: Notification received:', { subscriptionType: subType, event });
 
         // Skip own bot messages
         if (
             subType === 'channel.chat.message'
             && event?.['chatter_user_id'] === this.userId
-        ) return;
+        ) {
+            Logger.info('TwitchClient: Skipping own bot message');
+            return;
+        }
 
         const rawEvent: TwitchRawEvent = {
             subscriptionType: subType ?? '',
             event: event ?? {}
         };
 
+        Logger.info('TwitchClient: Routing to EventRouter');
         this.eventRouter.route(rawEvent);
     }
 

--- a/backend/src/twitch-client.ts
+++ b/backend/src/twitch-client.ts
@@ -1,9 +1,9 @@
-import WebSocket from 'ws';
 import fetch from 'node-fetch';
 import Logger from './utils/Logger.js';
+import { EventSubSession } from './EventSubSession.js';
+import type { EventSubNotification } from './EventSubSession.js';
 import type { TwitchRawEvent, IEventRouter, IOverlayBroadcaster } from './types.js';
 
-// Local interfaces for Twitch API responses — typed to what we actually use
 interface TwitchUserData {
     id: string
     display_name: string
@@ -22,17 +22,6 @@ interface TwitchSubscribeError {
     error?: string
 }
 
-interface EventSubMessage {
-    metadata: {
-        message_type: string
-    }
-    payload: {
-        session?: { id: string }
-        subscription?: { type: string }
-        event?: Record<string, unknown>
-    }
-}
-
 export interface TwitchClientOptions {
     accessToken?: string
     broadcasterToken?: string
@@ -43,8 +32,6 @@ export interface TwitchClientOptions {
 }
 
 export class TwitchClient {
-    private websocket: WebSocket | null;
-    private sessionId: string | null;
     private accessToken: string;
     private broadcasterToken: string;
     private clientId: string;
@@ -54,11 +41,10 @@ export class TwitchClient {
     private channelName: string | null;
     private overlayBroadcasterService: IOverlayBroadcaster | null;
     private eventRouter: IEventRouter | null;
+    private botSession: EventSubSession;
+    private broadcasterSession: EventSubSession | null;
 
     constructor(options: TwitchClientOptions = {}) {
-        this.websocket = null;
-        this.sessionId = null;
-
         const accessToken = options.accessToken ?? process.env.TWITCH_ACCESS_TOKEN;
         const clientId = options.clientId ?? process.env.TWITCH_CLIENT_ID;
 
@@ -76,6 +62,22 @@ export class TwitchClient {
         this.overlayBroadcasterService = options.overlayBroadcasterService ?? null;
         this.eventRouter = options.eventRouter ?? null;
 
+        const notify = (n: EventSubNotification) => this.handleNotification(n);
+
+        this.botSession = new EventSubSession(
+            this.accessToken, this.clientId, 'bot',
+            (sessionId) => this.subscribeBotEvents(sessionId),
+            notify
+        );
+
+        this.broadcasterSession = this.broadcasterToken !== this.accessToken
+            ? new EventSubSession(
+                this.broadcasterToken, this.clientId, 'broadcaster',
+                (sessionId) => this.subscribeBroadcasterEvents(sessionId),
+                notify
+            )
+            : null;
+
         this.init();
     }
 
@@ -89,7 +91,9 @@ export class TwitchClient {
         }
 
         await this.checkTokenScopes();
-        this.connectEventSub();
+
+        this.botSession.connect();
+        this.broadcasterSession?.connect();
     }
 
     setEventRouter(eventRouter: IEventRouter): void {
@@ -146,14 +150,13 @@ export class TwitchClient {
     }
 
     private async checkTokenScopes(): Promise<void> {
-        await this.validateScopes(this.accessToken, 'bot', [
-            'user:read:chat',
-            'user:write:chat',
-            'moderator:read:followers',
-            'moderator:read:chatters',
-        ]);
-
-        if (this.broadcasterToken !== this.accessToken) {
+        if (this.broadcasterSession) {
+            await this.validateScopes(this.accessToken, 'bot', [
+                'user:read:chat',
+                'user:write:chat',
+                'moderator:read:followers',
+                'moderator:read:chatters',
+            ]);
             await this.validateScopes(this.broadcasterToken, 'broadcaster', [
                 'channel:read:subscriptions',
                 'channel:read:redemptions',
@@ -191,71 +194,47 @@ export class TwitchClient {
         }
     }
 
-    private connectEventSub(): void {
-        this.websocket = new WebSocket('wss://eventsub.wss.twitch.tv/ws');
-
-        this.websocket.onopen = () => Logger.info('TwitchClient: EventSub connected');
-
-        this.websocket.onmessage = (event) => {
-            const message = JSON.parse(event.data as string) as EventSubMessage;
-            if (message.metadata.message_type === 'session_keepalive') return;
-            this.handleEventSubMessage(message);
-        };
-
-        this.websocket.onclose = (event) => {
-            Logger.warn('TwitchClient: EventSub closed:', event.code, event.reason);
-            setTimeout(() => this.connectEventSub(), 5000);
-        };
-
-        this.websocket.onerror = (error) => Logger.error('TwitchClient: WebSocket error:', error);
-    }
-
-    private async handleEventSubMessage(message: EventSubMessage): Promise<void> {
-        switch (message.metadata.message_type) {
-            case 'session_welcome':
-                this.sessionId = message.payload.session?.id ?? null;
-                Logger.info('TwitchClient: Session ready');
-                await this.subscribeToAll();
-                break;
-
-            case 'notification':
-                this.handleNotification(message);
-                break;
-
-            case 'session_reconnect':
-                Logger.info('TwitchClient: Reconnect requested');
-                break;
-        }
-    }
-
-    private async subscribeToAll(): Promise<void> {
+    private async subscribeBotEvents(sessionId: string): Promise<void> {
         await this.subscribe('channel.chat.message', '1', {
             broadcaster_user_id: this.channelId,
             user_id: this.userId
-        });
+        }, this.accessToken, sessionId);
+
         await this.subscribe('channel.follow', '2', {
             broadcaster_user_id: this.channelId,
             moderator_user_id: this.userId
-        });
-        await this.subscribe('channel.subscribe', '1', {
-            broadcaster_user_id: this.channelId
-        }, this.broadcasterToken);
+        }, this.accessToken, sessionId);
+
         await this.subscribe('channel.raid', '1', {
             to_broadcaster_user_id: this.channelId
-        });
+        }, this.accessToken, sessionId);
+
+        // In single-account mode, broadcaster events also go through this session
+        if (!this.broadcasterSession) {
+            await this.subscribeBroadcasterEvents(sessionId);
+        }
+    }
+
+    private async subscribeBroadcasterEvents(sessionId: string): Promise<void> {
+        await this.subscribe('channel.subscribe', '1', {
+            broadcaster_user_id: this.channelId
+        }, this.broadcasterToken, sessionId);
+
         await this.subscribe('channel.cheer', '1', {
             broadcaster_user_id: this.channelId
-        }, this.broadcasterToken);
+        }, this.broadcasterToken, sessionId);
+
         await this.subscribe('channel.channel_points_custom_reward_redemption.add', '1', {
             broadcaster_user_id: this.channelId
-        }, this.broadcasterToken);
+        }, this.broadcasterToken, sessionId);
     }
 
     private async subscribe(
         type: string,
         version: string,
         condition: Record<string, string | null>,
-        token: string = this.accessToken
+        token: string,
+        sessionId: string
     ): Promise<void> {
         try {
             const response = await fetch('https://api.twitch.tv/helix/eventsub/subscriptions', {
@@ -269,7 +248,7 @@ export class TwitchClient {
                     type,
                     version,
                     condition,
-                    transport: { method: 'websocket', session_id: this.sessionId }
+                    transport: { method: 'websocket', session_id: sessionId }
                 })
             });
 
@@ -284,27 +263,21 @@ export class TwitchClient {
         }
     }
 
-    handleNotification(message: EventSubMessage): void {
+    handleNotification(notification: EventSubNotification): void {
         if (!this.eventRouter) return;
 
-        const subType = message.payload.subscription?.type;
-        const event = message.payload.event;
-
-        Logger.info('TwitchClient: Notification received:', { subscriptionType: subType, event });
+        const { subscriptionType, event } = notification;
 
         // Skip own bot messages
         if (
-            subType === 'channel.chat.message'
-            && event?.['chatter_user_id'] === this.userId
+            subscriptionType === 'channel.chat.message'
+            && event['chatter_user_id'] === this.userId
         ) {
             Logger.info('TwitchClient: Skipping own bot message');
             return;
         }
 
-        const rawEvent: TwitchRawEvent = {
-            subscriptionType: subType ?? '',
-            event: event ?? {}
-        };
+        const rawEvent: TwitchRawEvent = { subscriptionType, event };
 
         Logger.info('TwitchClient: Routing to EventRouter');
         this.eventRouter.route(rawEvent);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "start": "npm run build && node dist/backend/index.js",
     "dev": "tsx --watch backend/index.ts",
     "start-fail": "node dist/backend/index.js",
-    "auth": "tsx auth.ts",
+    "auth:bot": "tsx auth.ts bot",
+    "auth:streamer": "tsx auth.ts streamer",
     "stream-check": "tsx verify-streaming-safety.ts",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary

- Extracts `EventSubSession` class to manage a single Twitch EventSub WebSocket connection
- `TwitchClient` now opens two sessions when `TWITCH_BROADCASTER_TOKEN` differs from `TWITCH_ACCESS_TOKEN` — one per user, since Twitch enforces that a WebSocket session can only be used by the account that created it
- Broadcaster-owned subscriptions (`channel.subscribe`, `channel.cheer`, `channel.channel_points_custom_reward_redemption.add`) use the broadcaster session; chat/follow/raid use the bot session
- Falls back to single-session mode when both tokens are the same account
- Splits `npm run auth` into `npm run auth:bot` and `npm run auth:streamer`, each requesting only the scopes relevant to that account

## Test plan

- [ ] `npm run auth:bot` produces a URL with only bot scopes
- [ ] `npm run auth:streamer` produces a URL with only broadcaster scopes
- [ ] With both tokens set, all 6 subscriptions succeed on startup
- [ ] With only `TWITCH_ACCESS_TOKEN` set (single-account mode), behaviour is unchanged
- [ ] Chat commands, follows, subs, cheers, and redemptions all trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)