### PR TITLE
[#63, #64] In-memory event log + Log UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,22 @@ gh issue list --state open
 ## Commands
 
 ```bash
-npm start          # Dev server with auto-reload (node --watch)
+npm start          # Clean build then serve (no watch)
+npm run dev        # Clean frontend build then serve backend
 npm run start-fail # Production start (no watch)
 npm run stream-check  # Verify streaming safety config
+npm test           # Run all tests once (vitest)
+npm run test:watch # Watch mode
 ```
 
-No test framework or linter is configured.
+## Testing
+
+Vitest is configured at the root. Tests live in `tests/` and mirror the `backend/src/` structure. Every new backend service or utility **must** have a corresponding test file — write tests in the same PR as the code.
+
+- Mock `Logger` in every test file that touches backend code (`vi.mock('../backend/src/utils/Logger.js', ...)`)
+- Singleton services (`EventLog`, `SessionStats`) must be `reset()` in `beforeEach`
+- Do not call `init()` on `EventRouter` in tests — inject `eventTypes` directly to bypass dynamic import
+- No linter is configured.
 
 ## Branch, Commit and PR Conventions
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -8,6 +8,7 @@ import OverlayBroadcasterService from './src/services/OverlayBroadcasterService.
 import { EVENTS } from './config/events.js';
 import Logger from './src/utils/Logger.js';
 import sessionStats from './src/SessionStats.js';
+import eventLog from './src/EventLog.js';
 import { wss, app } from './src/server.js';
 
 Logger.info('Starting Twitch project backend...');
@@ -53,6 +54,24 @@ app.get('/api/stream/stats', async (_req: Request, res: Response) => {
         : [null, null, null];
 
     res.json({ stream, followers, subscribers, session: sessionStats.snapshot() });
+});
+
+app.get('/api/log', (_req: Request, res: Response) => {
+    res.json(eventLog.getAll());
+});
+
+app.post('/api/log/:id/replay', async (req: Request, res: Response) => {
+    const entry = eventLog.getById(String(req.params.id));
+    if (!entry) {
+        res.status(404).json({ error: 'Log entry not found' });
+        return;
+    }
+    if (!eventRouter) {
+        res.status(503).json({ error: 'Event router not available' });
+        return;
+    }
+    await eventRouter.route({ subscriptionType: entry.subscriptionType, event: entry.data }, true);
+    res.json({ ok: true });
 });
 
 app.get('/api/status', (_req: Request, res: Response) => {

--- a/backend/src/EventLog.ts
+++ b/backend/src/EventLog.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from 'crypto';
+import Logger from './utils/Logger.js';
+
+export interface LogEntry {
+    id: string;
+    eventName: string;
+    eventType: string;
+    subscriptionType: string;
+    username: string;
+    detail: string;
+    timestamp: Date;
+    data: Record<string, unknown>;
+}
+
+const MAX_ENTRIES = 500;
+
+class EventLog {
+    private entries: LogEntry[] = [];
+
+    append(entry: Omit<LogEntry, 'id' | 'timestamp'>): void {
+        this.entries.unshift({
+            id: randomUUID(),
+            timestamp: new Date(),
+            ...entry,
+        });
+
+        if (this.entries.length > MAX_ENTRIES) {
+            this.entries.length = MAX_ENTRIES;
+        }
+    }
+
+    getAll(): LogEntry[] {
+        return this.entries;
+    }
+
+    getById(id: string): LogEntry | undefined {
+        return this.entries.find(e => e.id === id);
+    }
+
+    reset(): void {
+        this.entries = [];
+        Logger.info('EventLog: cleared for new stream');
+    }
+}
+
+export default new EventLog();

--- a/backend/src/EventRouter.ts
+++ b/backend/src/EventRouter.ts
@@ -7,8 +7,35 @@ import { BaseEventType } from './event-types/BaseEventType.js';
 import Logger from './utils/Logger.js';
 import type { EventConfig, TwitchRawEvent, TemplateData, ITwitchClient, IOverlayBroadcaster } from './types.js';
 import sessionStats from './SessionStats.js';
+import eventLog from './EventLog.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function extractDetail(subscriptionType: string, event: Record<string, unknown>): string {
+    switch (subscriptionType) {
+        case 'channel.follow':
+            return 'Followed the channel';
+        case 'channel.subscribe': {
+            const tier = String(event['tier'] ?? '1000');
+            const tierLabel = tier === '3000' ? 'Tier 3' : tier === '2000' ? 'Tier 2' : 'Tier 1';
+            return `Subscribed (${tierLabel})`;
+        }
+        case 'channel.cheer':
+            return `Cheered ${event['bits'] ?? '?'} bits`;
+        case 'channel.raid':
+            return `Raided with ${event['viewers'] ?? '?'} viewers`;
+        case 'channel.chat.message': {
+            const msg = event['message'] as Record<string, unknown> | undefined;
+            return String(msg?.['text'] ?? '');
+        }
+        case 'channel.channel_points_custom_reward_redemption.add': {
+            const reward = event['reward'] as Record<string, unknown> | undefined;
+            return `Redeemed: ${reward?.['title'] ?? 'Unknown reward'}`;
+        }
+        default:
+            return subscriptionType;
+    }
+}
 
 export class EventRouter extends Handler {
     eventTypes: BaseEventType[];
@@ -33,9 +60,10 @@ export class EventRouter extends Handler {
         Logger.info(`EventRouter: Loaded ${this.configs.length} event configs`);
     }
 
-    async route(rawEvent: TwitchRawEvent): Promise<void> {
-        Logger.info(`EventRouter: Routing "${rawEvent.subscriptionType}"`);
+    async route(rawEvent: TwitchRawEvent, replay = false): Promise<void> {
+        Logger.info(`EventRouter: Routing "${rawEvent.subscriptionType}"${replay ? ' (replay)' : ''}`);
         sessionStats.recordEvent(rawEvent.subscriptionType, rawEvent.event);
+
         let matched = false;
         for (const eventType of this.eventTypes) {
             for (const config of this.configs) {
@@ -43,10 +71,23 @@ export class EventRouter extends Handler {
                     Logger.info(`EventRouter: Matched [${eventType.type}] → "${config.event_name}"`);
                     const templateData: TemplateData = eventType.extractTemplateData(rawEvent);
                     await this.executeConfig(config, templateData);
+
+                    if (!replay) {
+                        eventLog.append({
+                            eventName:        config.event_name,
+                            eventType:        config.event_type,
+                            subscriptionType: rawEvent.subscriptionType,
+                            username:         templateData['username'] ?? templateData['display_name'] ?? 'unknown',
+                            detail:           extractDetail(rawEvent.subscriptionType, rawEvent.event),
+                            data:             rawEvent.event,
+                        });
+                    }
+
                     matched = true;
                 }
             }
         }
+
         if (!matched) {
             Logger.info(`EventRouter: No match for "${rawEvent.subscriptionType}"`);
         }
@@ -57,7 +98,6 @@ export class EventRouter extends Handler {
         const files = await readdir(dir);
 
         for (const file of files) {
-            // Accept .js (compiled) and .ts (tsx dev mode); skip declaration files
             if (file.endsWith('.d.ts')) continue;
             if (!file.endsWith('.js') && !file.endsWith('.ts')) continue;
 

--- a/backend/src/SessionStats.ts
+++ b/backend/src/SessionStats.ts
@@ -1,4 +1,5 @@
 import Logger from './utils/Logger.js';
+import eventLog from './EventLog.js';
 
 export interface StatsSnapshot {
     follows: number;
@@ -38,6 +39,7 @@ class SessionStats {
         this.chatMessages = 0;
         this.eventsFired = 0;
         this.raids = 0;
+        eventLog.reset();
         Logger.info('SessionStats: reset for new stream');
     }
 

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -42,5 +42,5 @@ export interface IOverlayBroadcaster {
 }
 
 export interface IEventRouter {
-    route(rawEvent: TwitchRawEvent): Promise<void>
+    route(rawEvent: TwitchRawEvent, replay?: boolean): Promise<void>
 }

--- a/frontend/src/components/EventLogSidebar.tsx
+++ b/frontend/src/components/EventLogSidebar.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface LogEntry {
+  id: string;
+  eventName: string;
+  eventType: string;
+  username: string;
+  detail: string;
+  timestamp: string;
+}
+
+async function fetchLog(): Promise<LogEntry[]> {
+  try {
+    const res = await fetch('/api/log');
+    if (!res.ok) return [];
+    return res.json() as Promise<LogEntry[]>;
+  } catch {
+    return [];
+  }
+}
+
+async function replay(id: string): Promise<void> {
+  await fetch(`/api/log/${id}/replay`, { method: 'POST' });
+}
+
+function formatTime(ts: string): string {
+  const d = new Date(ts);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function EventLogSidebar() {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const prevCountRef = useRef(0);
+
+  useEffect(() => {
+    fetchLog().then(setEntries);
+    const id = setInterval(() => fetchLog().then(setEntries), 5_000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    prevCountRef.current = entries.length;
+  }, [entries]);
+
+  return (
+    <div style={{
+      background: 'var(--surface)',
+      border: '1px solid var(--border)',
+      borderRadius: 8,
+      display: 'flex',
+      flexDirection: 'column',
+      maxHeight: 'calc(100vh - 120px)',
+      position: 'sticky',
+      top: 20,
+    }}>
+      <div style={{
+        padding: '14px 16px',
+        borderBottom: '1px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        flexShrink: 0,
+      }}>
+        <span style={{ fontSize: 14, fontWeight: 600 }}>Events Log</span>
+        <span style={{
+          fontSize: 11,
+          background: 'var(--accent)',
+          color: '#fff',
+          padding: '1px 7px',
+          borderRadius: 10,
+          fontWeight: 600,
+        }}>
+          {entries.length}
+        </span>
+      </div>
+
+      <div style={{ overflowY: 'auto', flex: 1, padding: '8px 0' }}>
+        {entries.map((entry, i) => (
+          <LogEntryRow
+            key={entry.id}
+            entry={entry}
+            isNew={i < entries.length - prevCountRef.current}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LogEntryRow({ entry, isNew }: { entry: LogEntry; isNew: boolean }) {
+  return (
+    <div style={{
+      padding: '10px 14px',
+      borderBottom: '1px solid #1a1a1d',
+      fontSize: 12,
+      animation: isNew ? 'slideIn 0.25s ease' : undefined,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
+            <span className={`event-type-badge ${entry.eventType}`}>{entry.eventType.replace(/_/g, ' ')}</span>
+            <span style={{ fontWeight: 600 }}>{entry.username}</span>
+          </div>
+          <div style={{ color: 'var(--muted)', fontSize: 11 }}>{entry.detail}</div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4, flexShrink: 0 }}>
+          <span style={{ fontSize: 10, color: 'var(--muted)', whiteSpace: 'nowrap' }}>
+            {formatTime(entry.timestamp)}
+          </span>
+          <button
+            onClick={() => replay(entry.id)}
+            style={{
+              background: 'transparent',
+              border: '1px solid var(--border)',
+              color: 'var(--muted)',
+              fontSize: 10,
+              fontWeight: 600,
+              padding: '2px 7px',
+              borderRadius: 4,
+              cursor: 'pointer',
+              whiteSpace: 'nowrap',
+            }}
+            onMouseEnter={e => { (e.target as HTMLButtonElement).style.color = 'var(--accent)'; (e.target as HTMLButtonElement).style.borderColor = 'var(--accent)'; }}
+            onMouseLeave={e => { (e.target as HTMLButtonElement).style.color = 'var(--muted)'; (e.target as HTMLButtonElement).style.borderColor = 'var(--border)'; }}
+          >
+            ▶ Replay
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,10 +1,32 @@
+import { useEffect, useState } from 'react';
 import StreamStatsPanel from '../components/StreamStatsPanel.tsx';
+import EventLogSidebar from '../components/EventLogSidebar.tsx';
+
+function useIsLive(): boolean {
+  const [isLive, setIsLive] = useState(false);
+
+  useEffect(() => {
+    const check = () =>
+      fetch('/api/stream/stats')
+        .then(r => r.json() as Promise<{ stream: unknown }>)
+        .then(data => setIsLive(data.stream !== null))
+        .catch(() => setIsLive(false));
+
+    check();
+    const id = setInterval(check, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return isLive;
+}
 
 export default function DashboardPage() {
+  const isLive = useIsLive();
+
   return (
     <div style={{
       display: 'grid',
-      gridTemplateColumns: '1fr 320px',
+      gridTemplateColumns: isLive ? '1fr 320px' : '1fr',
       gap: 20,
       alignItems: 'start',
     }}>
@@ -13,10 +35,11 @@ export default function DashboardPage() {
         <Placeholder label="Viewers" />
       </div>
 
-      {/* Log sidebar — shown when live (#64) */}
-      <aside style={{ display: 'none' }}>
-        <Placeholder label="Events log" />
-      </aside>
+      {isLive && (
+        <aside>
+          <EventLogSidebar />
+        </aside>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/LogPage.tsx
+++ b/frontend/src/pages/LogPage.tsx
@@ -1,14 +1,142 @@
+import { useEffect, useState } from 'react';
+
+interface LogEntry {
+  id: string;
+  eventName: string;
+  eventType: string;
+  username: string;
+  detail: string;
+  timestamp: string;
+}
+
+async function fetchLog(): Promise<LogEntry[]> {
+  try {
+    const res = await fetch('/api/log');
+    if (!res.ok) return [];
+    return res.json() as Promise<LogEntry[]>;
+  } catch {
+    return [];
+  }
+}
+
+async function replay(id: string): Promise<void> {
+  await fetch(`/api/log/${id}/replay`, { method: 'POST' });
+}
+
+function formatTime(ts: string): string {
+  const d = new Date(ts);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
 export default function LogPage() {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+
+  useEffect(() => {
+    fetchLog().then(setEntries);
+    const id = setInterval(() => fetchLog().then(setEntries), 5_000);
+    return () => clearInterval(id);
+  }, []);
+
   return (
-    <div style={{
-      background: 'var(--surface)',
-      border: '1px solid var(--border)',
-      borderRadius: 8,
-      padding: 24,
-      color: 'var(--muted)',
-      fontSize: 13,
-    }}>
-      Log
-    </div>
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+        <span style={{ fontSize: 16, fontWeight: 600 }}>Events Log</span>
+        <span style={{ fontSize: 12, color: 'var(--muted)' }}>
+          {entries.length} event{entries.length !== 1 ? 's' : ''} · in-memory only
+        </span>
+      </div>
+
+      <div style={{
+        background: 'var(--surface)',
+        border: '1px solid var(--border)',
+        borderRadius: 8,
+        overflow: 'hidden',
+      }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr>
+              {['Time', 'Type', 'User', 'Detail', ''].map(h => (
+                <th key={h} style={{
+                  textAlign: 'left',
+                  padding: '10px 16px',
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: 'var(--muted)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.4px',
+                  borderBottom: '1px solid var(--border)',
+                }}>
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length === 0 ? (
+              <tr>
+                <td colSpan={5} style={{ padding: '24px 16px', color: 'var(--muted)', textAlign: 'center' }}>
+                  No events yet this stream
+                </td>
+              </tr>
+            ) : entries.map((entry, i) => (
+              <tr key={entry.id}>
+                <td style={{
+                  padding: '10px 16px',
+                  borderBottom: i < entries.length - 1 ? '1px solid #1a1a1d' : undefined,
+                  color: 'var(--muted)',
+                  whiteSpace: 'nowrap',
+                }}>
+                  {formatTime(entry.timestamp)}
+                </td>
+                <td style={{ padding: '10px 16px', borderBottom: i < entries.length - 1 ? '1px solid #1a1a1d' : undefined }}>
+                  <span className={`event-type-badge ${entry.eventType}`}>
+                    {entry.eventType.replace(/_/g, ' ')}
+                  </span>
+                </td>
+                <td style={{ padding: '10px 16px', borderBottom: i < entries.length - 1 ? '1px solid #1a1a1d' : undefined }}>
+                  {entry.username}
+                </td>
+                <td style={{ padding: '10px 16px', borderBottom: i < entries.length - 1 ? '1px solid #1a1a1d' : undefined }}>
+                  {entry.detail}
+                </td>
+                <td style={{ padding: '10px 16px', borderBottom: i < entries.length - 1 ? '1px solid #1a1a1d' : undefined }}>
+                  <ReplayButton id={entry.id} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function ReplayButton({ id }: { id: string }) {
+  const [replaying, setReplaying] = useState(false);
+
+  const handleReplay = async () => {
+    setReplaying(true);
+    await replay(id);
+    setTimeout(() => setReplaying(false), 1000);
+  };
+
+  return (
+    <button
+      onClick={handleReplay}
+      disabled={replaying}
+      style={{
+        background: 'transparent',
+        border: '1px solid var(--border)',
+        color: replaying ? 'var(--accent)' : 'var(--muted)',
+        fontSize: 10,
+        fontWeight: 600,
+        padding: '2px 7px',
+        borderRadius: 4,
+        cursor: replaying ? 'default' : 'pointer',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {replaying ? '▶ Replaying…' : '▶ Replay'}
+    </button>
   );
 }

--- a/tests/EventLog.test.ts
+++ b/tests/EventLog.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import eventLog from '../backend/src/EventLog.js'
+
+vi.mock('../backend/src/utils/Logger.js', () => ({
+    default: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), log: vi.fn() },
+}))
+
+function makeEntry(overrides: Partial<Parameters<typeof eventLog.append>[0]> = {}) {
+    return {
+        eventName:        'test_event',
+        eventType:        'follow',
+        subscriptionType: 'channel.follow',
+        username:         'testuser',
+        detail:           'Followed the channel',
+        data:             { user_name: 'testuser' },
+        ...overrides,
+    }
+}
+
+describe('EventLog', () => {
+    beforeEach(() => {
+        eventLog.reset()
+    })
+
+    describe('append', () => {
+        it('adds an entry with a generated id and timestamp', () => {
+            eventLog.append(makeEntry())
+            const entries = eventLog.getAll()
+            expect(entries).toHaveLength(1)
+            expect(entries[0].id).toBeTruthy()
+            expect(entries[0].timestamp).toBeInstanceOf(Date)
+        })
+
+        it('stores all provided fields', () => {
+            const data = { user_id: '123', user_name: 'alice' }
+            eventLog.append(makeEntry({ username: 'alice', detail: 'Followed the channel', data }))
+            const entry = eventLog.getAll()[0]
+            expect(entry.username).toBe('alice')
+            expect(entry.detail).toBe('Followed the channel')
+            expect(entry.data).toEqual(data)
+        })
+
+        it('prepends — newest entry is first', () => {
+            eventLog.append(makeEntry({ username: 'first' }))
+            eventLog.append(makeEntry({ username: 'second' }))
+            const entries = eventLog.getAll()
+            expect(entries[0].username).toBe('second')
+            expect(entries[1].username).toBe('first')
+        })
+
+        it('caps at 500 entries', () => {
+            for (let i = 0; i < 510; i++) {
+                eventLog.append(makeEntry({ username: `user${i}` }))
+            }
+            expect(eventLog.getAll()).toHaveLength(500)
+        })
+
+        it('discards oldest entries when cap is exceeded', () => {
+            for (let i = 0; i < 501; i++) {
+                eventLog.append(makeEntry({ username: `user${i}` }))
+            }
+            const entries = eventLog.getAll()
+            // newest is user500, oldest kept is user1 (user0 dropped)
+            expect(entries[0].username).toBe('user500')
+            expect(entries[499].username).toBe('user1')
+        })
+    })
+
+    describe('getById', () => {
+        it('returns the matching entry', () => {
+            eventLog.append(makeEntry({ username: 'alice' }))
+            const id = eventLog.getAll()[0].id
+            expect(eventLog.getById(id)?.username).toBe('alice')
+        })
+
+        it('returns undefined for an unknown id', () => {
+            expect(eventLog.getById('does-not-exist')).toBeUndefined()
+        })
+    })
+
+    describe('reset', () => {
+        it('clears all entries', () => {
+            eventLog.append(makeEntry())
+            eventLog.append(makeEntry())
+            eventLog.reset()
+            expect(eventLog.getAll()).toHaveLength(0)
+        })
+    })
+})

--- a/tests/EventRouter.test.ts
+++ b/tests/EventRouter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { EventRouter } from '../backend/src/EventRouter.js'
 import { BaseEventType } from '../backend/src/event-types/BaseEventType.js'
 import type { EventConfig, TwitchRawEvent, TemplateData } from '../backend/src/types.js'
+import eventLog from '../backend/src/EventLog.js'
 
 // Suppress Logger output during tests
 vi.mock('../backend/src/utils/Logger.js', () => ({
@@ -49,6 +50,7 @@ describe('EventRouter', () => {
     beforeEach(() => {
         router = new EventRouter()
         // Do NOT call init() — inject eventTypes directly to bypass dynamic import
+        eventLog.reset()
     })
 
     describe('setConfigs', () => {
@@ -161,6 +163,105 @@ describe('EventRouter', () => {
             await router.route(makeRawEvent())
 
             expect(execSpy).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('event log integration', () => {
+        it('appends to the event log when a match is found', async () => {
+            const config = makeConfig({ event_name: 'lurk', event_type: 'chat_command' })
+            router.eventTypes.push(makeMockEventType(true, { username: 'alice' }))
+            router.setConfigs([config])
+            vi.spyOn(router, 'executeConfig').mockResolvedValue(undefined)
+
+            await router.route(makeRawEvent({ subscriptionType: 'channel.follow', event: {} }))
+
+            expect(eventLog.getAll()).toHaveLength(1)
+            expect(eventLog.getAll()[0].username).toBe('alice')
+            expect(eventLog.getAll()[0].eventName).toBe('lurk')
+        })
+
+        it('does not append to the event log when no match', async () => {
+            router.eventTypes.push(makeMockEventType(false))
+            router.setConfigs([makeConfig()])
+            vi.spyOn(router, 'executeConfig').mockResolvedValue(undefined)
+
+            await router.route(makeRawEvent())
+
+            expect(eventLog.getAll()).toHaveLength(0)
+        })
+
+        it('does not append to the event log when replay=true', async () => {
+            router.eventTypes.push(makeMockEventType(true, { username: 'alice' }))
+            router.setConfigs([makeConfig()])
+            vi.spyOn(router, 'executeConfig').mockResolvedValue(undefined)
+
+            await router.route(makeRawEvent(), true)
+
+            expect(eventLog.getAll()).toHaveLength(0)
+        })
+
+        it('appends one entry per matched config', async () => {
+            const configs = [makeConfig({ event_name: 'a' }), makeConfig({ event_name: 'b' })]
+            router.eventTypes.push(makeMockEventType(true, { username: 'bob' }))
+            router.setConfigs(configs)
+            vi.spyOn(router, 'executeConfig').mockResolvedValue(undefined)
+
+            await router.route(makeRawEvent())
+
+            expect(eventLog.getAll()).toHaveLength(2)
+        })
+    })
+
+    describe('extractDetail', () => {
+        async function routeAndGetDetail(subscriptionType: string, event: Record<string, unknown>) {
+            router.eventTypes.push(makeMockEventType(true, { username: 'x' }))
+            router.setConfigs([makeConfig()])
+            vi.spyOn(router, 'executeConfig').mockResolvedValue(undefined)
+            await router.route({ subscriptionType, event })
+            return eventLog.getAll()[0]?.detail
+        }
+
+        beforeEach(() => {
+            router = new EventRouter()
+            eventLog.reset()
+        })
+
+        it('describes a follow', async () => {
+            expect(await routeAndGetDetail('channel.follow', {})).toBe('Followed the channel')
+        })
+
+        it('describes a Tier 1 sub', async () => {
+            expect(await routeAndGetDetail('channel.subscribe', { tier: '1000' })).toBe('Subscribed (Tier 1)')
+        })
+
+        it('describes a Tier 2 sub', async () => {
+            expect(await routeAndGetDetail('channel.subscribe', { tier: '2000' })).toBe('Subscribed (Tier 2)')
+        })
+
+        it('describes a Tier 3 sub', async () => {
+            expect(await routeAndGetDetail('channel.subscribe', { tier: '3000' })).toBe('Subscribed (Tier 3)')
+        })
+
+        it('describes a cheer with bit count', async () => {
+            expect(await routeAndGetDetail('channel.cheer', { bits: 500 })).toBe('Cheered 500 bits')
+        })
+
+        it('describes a raid with viewer count', async () => {
+            expect(await routeAndGetDetail('channel.raid', { viewers: 120 })).toBe('Raided with 120 viewers')
+        })
+
+        it('describes a chat message with its text', async () => {
+            expect(await routeAndGetDetail('channel.chat.message', { message: { text: '!lurk' } })).toBe('!lurk')
+        })
+
+        it('describes a channel points redemption with reward title', async () => {
+            const event = { reward: { title: 'Hydrate!' } }
+            expect(await routeAndGetDetail('channel.channel_points_custom_reward_redemption.add', event))
+                .toBe('Redeemed: Hydrate!')
+        })
+
+        it('falls back to subscriptionType for unknown events', async () => {
+            expect(await routeAndGetDetail('channel.unknown.event', {})).toBe('channel.unknown.event')
         })
     })
 })

--- a/tests/SessionStats.test.ts
+++ b/tests/SessionStats.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import sessionStats from '../backend/src/SessionStats.js'
+import eventLog from '../backend/src/EventLog.js'
+
+vi.mock('../backend/src/utils/Logger.js', () => ({
+    default: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), log: vi.fn() },
+}))
+
+describe('SessionStats', () => {
+    beforeEach(() => {
+        sessionStats.reset()
+    })
+
+    describe('recordEvent', () => {
+        it('increments follows on channel.follow', () => {
+            sessionStats.recordEvent('channel.follow', {})
+            expect(sessionStats.snapshot().follows).toBe(1)
+        })
+
+        it('increments subs on channel.subscribe', () => {
+            sessionStats.recordEvent('channel.subscribe', {})
+            expect(sessionStats.snapshot().subs).toBe(1)
+        })
+
+        it('adds bits amount on channel.cheer', () => {
+            sessionStats.recordEvent('channel.cheer', { bits: 500 })
+            sessionStats.recordEvent('channel.cheer', { bits: 100 })
+            expect(sessionStats.snapshot().bits).toBe(600)
+        })
+
+        it('defaults bits to 0 when missing', () => {
+            sessionStats.recordEvent('channel.cheer', {})
+            expect(sessionStats.snapshot().bits).toBe(0)
+        })
+
+        it('increments raids on channel.raid', () => {
+            sessionStats.recordEvent('channel.raid', {})
+            expect(sessionStats.snapshot().raids).toBe(1)
+        })
+
+        it('increments chatMessages on channel.chat.message', () => {
+            sessionStats.recordEvent('channel.chat.message', {})
+            sessionStats.recordEvent('channel.chat.message', {})
+            expect(sessionStats.snapshot().chatMessages).toBe(2)
+        })
+
+        it('increments eventsFired for every matched event', () => {
+            sessionStats.recordEvent('channel.follow', {})
+            sessionStats.recordEvent('channel.subscribe', {})
+            sessionStats.recordEvent('channel.cheer', { bits: 100 })
+            expect(sessionStats.snapshot().eventsFired).toBe(3)
+        })
+
+        it('does NOT increment eventsFired for channel.stream.online', () => {
+            sessionStats.recordEvent('channel.stream.online', {})
+            expect(sessionStats.snapshot().eventsFired).toBe(0)
+        })
+
+        it('resets all counters on channel.stream.online', () => {
+            sessionStats.recordEvent('channel.follow', {})
+            sessionStats.recordEvent('channel.subscribe', {})
+            sessionStats.recordEvent('channel.stream.online', {})
+            const snap = sessionStats.snapshot()
+            expect(snap.follows).toBe(0)
+            expect(snap.subs).toBe(0)
+            expect(snap.eventsFired).toBe(0)
+        })
+
+        it('also clears the event log on channel.stream.online', () => {
+            eventLog.append({
+                eventName: 'test', eventType: 'follow', subscriptionType: 'channel.follow',
+                username: 'alice', detail: 'Followed', data: {},
+            })
+            sessionStats.recordEvent('channel.stream.online', {})
+            expect(eventLog.getAll()).toHaveLength(0)
+        })
+
+        it('ignores unknown subscription types without throwing', () => {
+            expect(() => sessionStats.recordEvent('channel.unknown', {})).not.toThrow()
+        })
+    })
+
+    describe('snapshot', () => {
+        it('returns a copy of current counters', () => {
+            sessionStats.recordEvent('channel.follow', {})
+            const snap = sessionStats.snapshot()
+            expect(snap).toEqual({ follows: 1, subs: 0, bits: 0, chatMessages: 0, eventsFired: 1, raids: 0 })
+        })
+    })
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('../backend/src/server.js', () => ({
     wss: { clients: new Set(), on: vi.fn() },
-    app: {},
+    app: { get: vi.fn(), post: vi.fn(), use: vi.fn() },
     server: {}
 }))
 


### PR DESCRIPTION
## Summary
Covers #63 (backend) and #64 (UI).

**Backend**
- `EventLog` singleton — stores up to 500 entries (newest first), each with `id`, `eventName`, `eventType`, `subscriptionType`, `username`, `detail`, `timestamp`, and the **full raw Twitch event object** as `data`
- `EventRouter.route()` appends to the log on every matched event; skips logging when `replay = true`
- `channel.stream.online` clears both `SessionStats` and `EventLog` via `SessionStats.reset()`
- `GET /api/log` — returns full log newest first
- `POST /api/log/:id/replay` — looks up entry, re-routes `{ subscriptionType, data }` through EventRouter without creating a new log entry

**Frontend**
- `EventLogSidebar` — sticky right column on Dashboard, polls every 5 s, visible only when stream is live; new entries animate in; Replay button per entry
- `LogPage` — full-width table with Time, Type, User, Detail, Replay; Replay button shows "Replaying…" feedback for 1 s
- `DashboardPage` — polls `/api/stream/stats` for live state; switches grid from `1fr` to `1fr 320px` and mounts sidebar when live

## Test plan
- [ ] `npm run build` (backend TS) passes
- [ ] `npm run build:frontend` passes
- [ ] `GET /api/log` returns `[]` on fresh start
- [ ] Events appear in log after triggering a chat command / follow / etc.
- [ ] `POST /api/log/:id/replay` re-fires the overlay effect without adding a new log entry
- [ ] Log clears when `channel.stream.online` fires
- [ ] Sidebar appears on Dashboard when live, hidden when offline
- [ ] Log page shows empty state when no events

🤖 Generated with [Claude Code](https://claude.com/claude-code)