### PR TITLE
[#81] Restructure EventConfig: reactions array with per-reaction fields

### DIFF
--- a/backend/config/events.ts
+++ b/backend/config/events.ts
@@ -5,76 +5,81 @@ export const EVENTS: Record<string, EventConfig> = {
         event_name: 'lurk',
         event_type: 'channel_points_redemption',
         trigger_on: ['lurk'],
-        image: 'lurk.png',
-        sound: 'lurk.mp3',
-        text: '{{username}}',
-        reply: 'Thank you for lurking, {{username}}!',
-        transition_in: 'fade-in',
-        transition_out: 'fade-out',
-        timeout: '6s'
+        reactions: [
+            { type: 'chat_reply', message: 'Thank you for lurking, {{username}}!' },
+            { type: 'image', url: 'lurk.png', transition_in: 'fade-in', transition_out: 'fade-out', timeout: '6s' },
+            { type: 'overlay_text', text: '{{username}}', transition_in: 'fade-in', transition_out: 'fade-out', timeout: '6s' },
+            { type: 'sound', filename: 'lurk.mp3' },
+        ],
     },
     discord: {
         event_name: 'discord',
         event_type: 'chat_command',
         trigger_on: ['discord'],
-        reply: '\nJoin our Discord: https://discord.vulps.co.uk',
+        reactions: [
+            { type: 'chat_reply', message: '\nJoin our Discord: https://discord.vulps.co.uk' },
+        ],
     },
     sus: {
         event_name: 'sus',
         event_type: 'chat_command',
         trigger_on: ['sus'],
-        sound: 'lurk.mp3',
-        reply: '{{username}} is sus!',
+        reactions: [
+            { type: 'chat_reply', message: '{{username}} is sus!' },
+            { type: 'sound', filename: 'lurk.mp3' },
+        ],
     },
     dancingfox: {
         event_name: 'dancingfox',
         event_type: 'chat_command',
         trigger_on: ['dancingfox'],
-        video: 'follow-dance.mp4'
+        reactions: [
+            { type: 'video', filename: 'follow-dance.mp4' },
+        ],
     },
     vindication: {
         event_name: 'vindication',
         event_type: 'chat_command',
         trigger_on: ['vindication'],
-        sound: 'vindication.mp3',
-        volume: 1.0,
-        reply: 'Vindication sound played for {{username}}!'
+        reactions: [
+            { type: 'chat_reply', message: 'Vindication sound played for {{username}}!' },
+            { type: 'sound', filename: 'vindication.mp3', volume: 1.0 },
+        ],
     },
     spam: {
         event_name: 'spam',
         event_type: 'chat_command',
         trigger_on: ['spam'],
-        reply: '!spam',
+        reactions: [
+            { type: 'chat_reply', message: '!spam' },
+        ],
     },
     follow: {
         event_name: 'follow',
         event_type: 'follow',
-        text: '{{username}} is following!',
-        video: 'follow-dance.mp4',
-        sound: 'follow.mp3',
-        reply: 'Thanks {{username}} for the follow!',
-        transition_in: 'bounce-in',
-        transition_out: 'bounce-out',
-        timeout: '20s'
+        reactions: [
+            { type: 'chat_reply', message: 'Thanks {{username}} for the follow!' },
+            { type: 'overlay_text', text: '{{username}} is following!', transition_in: 'bounce-in', transition_out: 'bounce-out', timeout: '20s' },
+            { type: 'video', filename: 'follow-dance.mp4', transition_in: 'bounce-in', transition_out: 'bounce-out', timeout: '20s' },
+            { type: 'sound', filename: 'follow.mp3' },
+        ],
     },
     subscription: {
         event_name: 'subscription',
         event_type: 'subscription',
-        text: '{{username}} just subscribed!',
-        reply: 'Welcome to the community, {{username}}!',
-        transition_in: 'scale-in',
-        transition_out: 'scale-out',
-        timeout: '6s'
+        reactions: [
+            { type: 'chat_reply', message: 'Welcome to the community, {{username}}!' },
+            { type: 'overlay_text', text: '{{username}} just subscribed!', transition_in: 'scale-in', transition_out: 'scale-out', timeout: '6s' },
+        ],
     },
     raid: {
         event_name: 'raid',
         event_type: 'raid',
-        text: '{{username}} is raiding with {{count}} viewers!',
-        reply: 'Thanks for the raid, {{username}}!',
-        transition_in: 'slide-right-in',
-        transition_out: 'slide-right-out',
-        timeout: '8s'
-    }
+        reactions: [
+            { type: 'chat_reply', message: 'Thanks for the raid, {{username}}!' },
+            { type: 'overlay_text', text: '{{username}} is raiding with {{count}} viewers!', transition_in: 'slide-right-in', transition_out: 'slide-right-out', timeout: '8s' },
+        ],
+    },
 };
 
 export default EVENTS;

--- a/backend/src/base/Handler.ts
+++ b/backend/src/base/Handler.ts
@@ -1,5 +1,5 @@
 import Logger from '../utils/Logger.js';
-import type { EventConfig, ITwitchClient, IOverlayBroadcaster, OverlayEvent, TemplateData } from '../types.js';
+import type { EventConfig, ITwitchClient, IOverlayBroadcaster, OverlayEvent, OverlayReaction, TemplateData } from '../types.js';
 
 export class Handler {
     protected twitchClient: ITwitchClient | null;
@@ -16,32 +16,35 @@ export class Handler {
     async executeConfig(config: EventConfig, templateData: TemplateData): Promise<void> {
         Logger.info(`Handler: Executing "${config.event_name}"`);
 
-        if (config.reply) {
-            if (this.twitchClient) {
-                const message = this.processTemplate(config.reply, templateData);
-                Logger.info(`Handler: Sending chat reply: "${message}"`);
-                const ok = await this.twitchClient.sendChatMessage(message);
-                Logger.info(`Handler: Chat reply ${ok ? 'sent' : 'FAILED'}`);
+        const overlayReactions: OverlayReaction[] = [];
+
+        for (const reaction of config.reactions) {
+            if (reaction.type === 'chat_reply') {
+                if (this.twitchClient) {
+                    const message = this.processTemplate(reaction.message, templateData);
+                    Logger.info(`Handler: Sending chat reply: "${message}"`);
+                    const ok = await this.twitchClient.sendChatMessage(message);
+                    Logger.info(`Handler: Chat reply ${ok ? 'sent' : 'FAILED'}`);
+                } else {
+                    Logger.warn('Handler: Skipping reply — twitchClient not set');
+                }
+            } else if (reaction.type === 'overlay_text') {
+                overlayReactions.push({
+                    ...reaction,
+                    text: this.processTemplate(reaction.text, templateData),
+                });
             } else {
-                Logger.warn('Handler: Skipping reply — twitchClient not set');
+                overlayReactions.push(reaction);
             }
         }
 
-        if (config.image || config.sound || config.text || config.video) {
-            const overlayEvent: OverlayEvent = {
-                type: 'event',
-                event_name: config.event_name,
-                image: config.image,
-                sound: config.sound,
-                volume: config.volume,
-                video: config.video,
-                text: this.processTemplate(config.text, templateData),
-                transition_in: config.transition_in,
-                transition_out: config.transition_out,
-                timeout: config.timeout
-            };
-
+        if (overlayReactions.length > 0) {
             if (this.overlayBroadcasterService) {
+                const overlayEvent: OverlayEvent = {
+                    type: 'event',
+                    event_name: config.event_name,
+                    reactions: overlayReactions,
+                };
                 Logger.info(`Handler: Broadcasting overlay event for "${config.event_name}"`);
                 await this.overlayBroadcasterService.broadcast(overlayEvent);
             } else {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,16 +1,52 @@
+export interface ChatReplyReaction {
+    type: 'chat_reply'
+    message: string
+}
+
+export interface OverlayTextReaction {
+    type: 'overlay_text'
+    text: string
+    transition_in?: string
+    transition_out?: string
+    timeout?: string
+}
+
+export interface ImageReaction {
+    type: 'image'
+    url: string
+    offsetX?: number
+    offsetY?: number
+    offsetZ?: number
+    transition_in?: string
+    transition_out?: string
+    timeout?: string
+}
+
+export interface SoundReaction {
+    type: 'sound'
+    filename: string
+    volume?: number
+}
+
+export interface VideoReaction {
+    type: 'video'
+    filename: string
+    offsetX?: number
+    offsetY?: number
+    offsetZ?: number
+    transition_in?: string
+    transition_out?: string
+    timeout?: string
+}
+
+export type OverlayReaction = OverlayTextReaction | ImageReaction | SoundReaction | VideoReaction
+export type Reaction = ChatReplyReaction | OverlayReaction
+
 export interface EventConfig {
     event_name: string
     event_type: string
     trigger_on?: string[]
-    reply?: string
-    image?: string
-    sound?: string
-    volume?: number
-    video?: string
-    text?: string
-    transition_in?: string
-    transition_out?: string
-    timeout?: string
+    reactions: Reaction[]
 }
 
 export type TemplateData = Record<string, string>
@@ -23,14 +59,7 @@ export interface TwitchRawEvent {
 export interface OverlayEvent {
     type: 'event'
     event_name: string
-    image?: string
-    sound?: string
-    volume?: number
-    video?: string
-    text?: string
-    transition_in?: string
-    transition_out?: string
-    timeout?: string
+    reactions: OverlayReaction[]
 }
 
 export interface ITwitchClient {

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -207,11 +207,10 @@
                 this.overlayContainer = document.getElementById('overlay-container');
                 this.currentDisplay = null;
                 this.displayTimeout = null;
+                this._transitionOut = 'fade-out';
                 this.reconnectAttempts = 0;
                 this.maxReconnectAttempts = 5;
                 this.reconnectDelay = 1000; // Start with 1 second
-
-                // Media end handling is now done directly in onended callbacks
 
                 this.connect();
             }
@@ -275,9 +274,6 @@
                     case 'connection':
                         console.log('Backend connection confirmed:', data.message);
                         break;
-                    case 'command':
-                        this.displayCommand(data);
-                        break;
                     case 'event':
                         this.displayEvent(data);
                         break;
@@ -289,118 +285,83 @@
                 }
             }
 
-            displayCommand(commandData) {
-
-                const shouldqueue = this.shouldQueue();
-
-                if (shouldqueue) {
-                    this.queuedConfigs.push(commandData);
-                    return;
-                }
-
-                // Clear any existing display
-                this.clearDisplay();
-
-                // Create display element
-                const displayElement = document.createElement('div');
-                displayElement.className = 'command-output';
-
-                // Add content based on what's available
-                let hasContent = false;
-
-                // Add video if specified
-                if (commandData.video) {
-                    const video = document.createElement('video');
-                    video.className = 'command-video';
-                    video.src = `/assets/video/${commandData.video}`;
-                    video.autoplay = true;
-                    video.muted = true; // Muted to allow autoplay in browsers
-                    video.loop = false;
-                    video.controls = false;
-
-                    // Handle video load errors
-                    video.onerror = () => {
-                        console.warn(`Video not found: ${commandData.video}`);
-                    };
-
-                    // Optional: Log when video starts/ends
-                    video.onloadeddata = () => {
-                        console.log(`Video loaded: ${commandData.video}`);
-                        this.playingMedia.push(video);
-                    };
-
-                    video.onended = () => {
-                        console.log(`Video ended: ${commandData.video}`);
-                        this.onMediaEnded(video, 'video', commandData.video);
-                    };
-
-                    displayElement.appendChild(video);
-                    hasContent = true;
-                }
-
-                // Add image if specified (and no video)
-                if (commandData.image && !commandData.video) {
-                    const img = document.createElement('img');
-                    img.className = 'command-image';
-                    img.src = `/assets/img/${commandData.image}`;
-                    img.alt = commandData.command_name || 'Command Image';
-
-                    // Handle image load errors
-                    img.onerror = () => {
-                        console.warn(`Image not found: ${commandData.image}`);
-                        // Optionally, you could fallback to a default image or remove the element
-                    };
-
-                    displayElement.appendChild(img);
-                    hasContent = true;
-                }
-
-                // Add text if specified
-                if (commandData.text && commandData.text.trim()) {
-                    const textDiv = document.createElement('div');
-                    textDiv.className = 'command-text';
-                    textDiv.textContent = commandData.text;
-                    displayElement.appendChild(textDiv);
-                    hasContent = true;
-                }
-
-                // Play sound regardless of visual content
-                if (commandData.sound) {
-                    this.playSound(commandData.sound, commandData.volume);
-                }
-
-                // Only display visual elements if we have content
-                if (hasContent) {
-                    // Add transition classes
-                    if (commandData.transition_in) {
-                        displayElement.classList.add(commandData.transition_in);
-                    }
-
-                    // Add to overlay
-                    this.overlayContainer.appendChild(displayElement);
-                    this.currentDisplay = displayElement;
-
-                    // Set timeout for removal
-                    const timeout = this.parseTimeout(commandData.timeout) || 5000; // Default 5 seconds
-                    this.displayTimeout = setTimeout(() => {
-                        this.hideDisplay(commandData.transition_out);
-                    }, timeout);
-                }
-            }
-
             shouldQueue() {
                 return this.currentDisplay !== null || this.playingMedia.length > 0;
             }
 
-            /**
-             * @deprecated Use displayCommand for command events only.
-             * This method can be extended to handle different event types in the future.
-            **/
             displayEvent(eventData) {
-                // Handle different event types (can be extended for follow, subscribe, etc.)
-                console.log('Displaying event:', eventData);
-                // For now, treat events similar to commands
-                this.displayCommand(eventData);
+                if (this.shouldQueue()) {
+                    this.queuedConfigs.push(eventData);
+                    return;
+                }
+
+                this.clearDisplay();
+
+                const reactions = eventData.reactions || [];
+                const displayElement = document.createElement('div');
+                displayElement.className = 'command-output';
+                let hasVisual = false;
+                let transitionOut = 'fade-out';
+                let timeout = null;
+
+                for (const reaction of reactions) {
+                    switch (reaction.type) {
+                        case 'sound':
+                            this.playSound(reaction.filename, reaction.volume);
+                            break;
+                        case 'image': {
+                            const img = document.createElement('img');
+                            img.className = 'command-image';
+                            img.src = `/assets/img/${reaction.url}`;
+                            img.alt = eventData.event_name || 'Event image';
+                            if (reaction.transition_in) img.classList.add(reaction.transition_in);
+                            img.onerror = () => console.warn(`Image not found: ${reaction.url}`);
+                            displayElement.appendChild(img);
+                            if (reaction.transition_out) transitionOut = reaction.transition_out;
+                            if (reaction.timeout && timeout === null) timeout = this.parseTimeout(reaction.timeout);
+                            hasVisual = true;
+                            break;
+                        }
+                        case 'video': {
+                            const video = document.createElement('video');
+                            video.className = 'command-video';
+                            video.src = `/assets/video/${reaction.filename}`;
+                            video.autoplay = true;
+                            video.muted = true;
+                            video.loop = false;
+                            video.controls = false;
+                            if (reaction.transition_in) video.classList.add(reaction.transition_in);
+                            video.onerror = () => console.warn(`Video not found: ${reaction.filename}`);
+                            video.onloadeddata = () => this.playingMedia.push(video);
+                            video.onended = () => this.onMediaEnded(video, 'video', reaction.filename);
+                            displayElement.appendChild(video);
+                            if (reaction.transition_out) transitionOut = reaction.transition_out;
+                            if (reaction.timeout && timeout === null) timeout = this.parseTimeout(reaction.timeout);
+                            hasVisual = true;
+                            break;
+                        }
+                        case 'overlay_text': {
+                            const textDiv = document.createElement('div');
+                            textDiv.className = 'command-text';
+                            textDiv.textContent = reaction.text;
+                            if (reaction.transition_in) textDiv.classList.add(reaction.transition_in);
+                            displayElement.appendChild(textDiv);
+                            if (reaction.transition_out) transitionOut = reaction.transition_out;
+                            if (reaction.timeout && timeout === null) timeout = this.parseTimeout(reaction.timeout);
+                            hasVisual = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (hasVisual) {
+                    this.overlayContainer.appendChild(displayElement);
+                    this.currentDisplay = displayElement;
+                    this._transitionOut = transitionOut;
+                    this.displayTimeout = setTimeout(() => {
+                        this.hideDisplay(this._transitionOut);
+                    }, timeout !== null ? timeout : 5000);
+                }
             }
 
             hideDisplay(transitionOut = 'fade-out') {
@@ -457,10 +418,9 @@
                 // Remove from playing media array
                 this.playingMedia = this.playingMedia.filter(media => media !== mediaElement);
                 
-                // Process next queued command if any
                 if (this.queuedConfigs.length > 0) {
                     const nextConfig = this.queuedConfigs.shift();
-                    this.displayCommand(nextConfig);
+                    this.displayEvent(nextConfig);
                 }
             }
 

--- a/tests/EventRouter.test.ts
+++ b/tests/EventRouter.test.ts
@@ -21,6 +21,7 @@ function makeConfig(overrides: Partial<EventConfig> = {}): EventConfig {
     return {
         event_name: 'test_event',
         event_type: 'chat_command',
+        reactions: [],
         ...overrides,
     }
 }

--- a/tests/base/Handler.test.ts
+++ b/tests/base/Handler.test.ts
@@ -2,9 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Handler } from '../../backend/src/base/Handler.js'
 import type { ITwitchClient, IOverlayBroadcaster, EventConfig } from '../../backend/src/types.js'
 
+vi.mock('../../backend/src/utils/Logger.js', () => ({
+    default: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), log: vi.fn() },
+}))
+
 const baseConfig: EventConfig = {
     event_name: 'test_event',
     event_type: 'chat_command',
+    reactions: [],
 }
 
 describe('Handler.processTemplate', () => {
@@ -44,69 +49,122 @@ describe('Handler.executeConfig', () => {
     let handler: Handler
 
     beforeEach(() => {
-        mockTwitchClient = { sendChatMessage: vi.fn().mockResolvedValue(undefined) }
-        mockOverlay = { broadcast: vi.fn().mockResolvedValue(undefined) }
+        mockTwitchClient = { sendChatMessage: vi.fn().mockResolvedValue(true) }
+        mockOverlay = { broadcast: vi.fn().mockResolvedValue(true) }
         handler = new Handler(mockTwitchClient, mockOverlay)
     })
 
-    it('sends a chat reply when config.reply is set', async () => {
-        await handler.executeConfig({ ...baseConfig, reply: 'Hello {{username}}!' }, { username: 'Bob' })
+    it('sends a chat reply when a chat_reply reaction is present', async () => {
+        await handler.executeConfig({
+            ...baseConfig,
+            reactions: [{ type: 'chat_reply', message: 'Hello {{username}}!' }],
+        }, { username: 'Bob' })
         expect(mockTwitchClient.sendChatMessage).toHaveBeenCalledWith('Hello Bob!')
     })
 
     it('does not send a chat reply when twitchClient is null', async () => {
         const h = new Handler(null, mockOverlay)
-        await h.executeConfig({ ...baseConfig, reply: 'Hello!' }, {})
+        await h.executeConfig({
+            ...baseConfig,
+            reactions: [{ type: 'chat_reply', message: 'Hello!' }],
+        }, {})
         expect(mockTwitchClient.sendChatMessage).not.toHaveBeenCalled()
     })
 
-    it('broadcasts an overlay event when config.image is set', async () => {
-        await handler.executeConfig({ ...baseConfig, image: 'alert.png' }, {})
+    it('broadcasts an overlay event when an image reaction is present', async () => {
+        await handler.executeConfig({
+            ...baseConfig,
+            reactions: [{ type: 'image', url: 'alert.png' }],
+        }, {})
         expect(mockOverlay.broadcast).toHaveBeenCalledWith(expect.objectContaining({
             type: 'event',
             event_name: 'test_event',
-            image: 'alert.png'
+            reactions: expect.arrayContaining([
+                expect.objectContaining({ type: 'image', url: 'alert.png' })
+            ]),
         }))
     })
 
-    it('broadcasts when config.sound is set', async () => {
-        await handler.executeConfig({ ...baseConfig, sound: 'alert.mp3' }, {})
+    it('broadcasts when a sound reaction is present', async () => {
+        await handler.executeConfig({
+            ...baseConfig,
+            reactions: [{ type: 'sound', filename: 'alert.mp3' }],
+        }, {})
         expect(mockOverlay.broadcast).toHaveBeenCalled()
     })
 
-    it('does not broadcast when no media fields are set', async () => {
-        await handler.executeConfig({ ...baseConfig, reply: 'hi' }, {})
+    it('does not broadcast when reactions list is empty', async () => {
+        await handler.executeConfig({ ...baseConfig, reactions: [] }, {})
+        expect(mockOverlay.broadcast).not.toHaveBeenCalled()
+    })
+
+    it('does not broadcast when all reactions are chat_reply', async () => {
+        await handler.executeConfig({
+            ...baseConfig,
+            reactions: [{ type: 'chat_reply', message: 'hi' }],
+        }, {})
         expect(mockOverlay.broadcast).not.toHaveBeenCalled()
     })
 
     it('does not broadcast when overlayBroadcasterService is null', async () => {
         const h = new Handler(mockTwitchClient, null)
-        await h.executeConfig({ ...baseConfig, image: 'alert.png' }, {})
+        await h.executeConfig({
+            ...baseConfig,
+            reactions: [{ type: 'image', url: 'alert.png' }],
+        }, {})
         expect(mockOverlay.broadcast).not.toHaveBeenCalled()
     })
 
-    it('processes template tokens in the overlay text field', async () => {
-        await handler.executeConfig({ ...baseConfig, image: 'x.png', text: '{{username}} arrived!' }, { username: 'Eve' })
+    it('processes template tokens in the overlay_text reaction', async () => {
+        await handler.executeConfig({
+            ...baseConfig,
+            reactions: [
+                { type: 'image', url: 'x.png' },
+                { type: 'overlay_text', text: '{{username}} arrived!' },
+            ],
+        }, { username: 'Eve' })
         expect(mockOverlay.broadcast).toHaveBeenCalledWith(expect.objectContaining({
-            text: 'Eve arrived!'
+            reactions: expect.arrayContaining([
+                expect.objectContaining({ type: 'overlay_text', text: 'Eve arrived!' }),
+            ]),
         }))
+    })
+
+    it('broadcasts all non-chat reactions together in one event', async () => {
+        await handler.executeConfig({
+            ...baseConfig,
+            reactions: [
+                { type: 'chat_reply', message: 'hi' },
+                { type: 'image', url: 'img.png' },
+                { type: 'sound', filename: 'snd.mp3' },
+            ],
+        }, {})
+        expect(mockOverlay.broadcast).toHaveBeenCalledTimes(1)
+        const call = (mockOverlay.broadcast as ReturnType<typeof vi.fn>).mock.calls[0][0]
+        expect(call.reactions).toHaveLength(2)
     })
 })
 
 describe('Handler.setTwitchClient / setOverlayBroadcasterService', () => {
     it('allows late injection of twitchClient', async () => {
         const handler = new Handler()
-        const client: ITwitchClient = { sendChatMessage: vi.fn().mockResolvedValue(undefined) }
+        const client: ITwitchClient = { sendChatMessage: vi.fn().mockResolvedValue(true) }
         handler.setTwitchClient(client)
-        await handler.executeConfig({ ...baseConfig, reply: 'Hi!' }, {})
+        await handler.executeConfig({
+            ...baseConfig,
+            reactions: [{ type: 'chat_reply', message: 'Hi!' }],
+        }, {})
         expect(client.sendChatMessage).toHaveBeenCalledWith('Hi!')
     })
 
     it('allows late injection of overlayBroadcasterService', async () => {
         const handler = new Handler()
-        const overlay: IOverlayBroadcaster = { broadcast: vi.fn().mockResolvedValue(undefined) }
+        const overlay: IOverlayBroadcaster = { broadcast: vi.fn().mockResolvedValue(true) }
         handler.setOverlayBroadcasterService(overlay)
-        await handler.executeConfig({ ...baseConfig, image: 'x.png' }, {})
+        await handler.executeConfig({
+            ...baseConfig,
+            reactions: [{ type: 'image', url: 'x.png' }],
+        }, {})
         expect(overlay.broadcast).toHaveBeenCalled()
     })
 })

--- a/tests/config/events.test.ts
+++ b/tests/config/events.test.ts
@@ -3,6 +3,7 @@ import { EVENTS } from '../../backend/config/events.js'
 
 const TRIGGER_REQUIRED_TYPES = new Set(['chat_command', 'chat_contains', 'channel_points_redemption'])
 const VALID_TYPES = new Set(['chat_command', 'chat_contains', 'follow', 'subscription', 'raid', 'bits', 'channel_points_redemption'])
+const VALID_REACTION_TYPES = new Set(['chat_reply', 'overlay_text', 'image', 'sound', 'video'])
 
 describe('EVENTS config', () => {
     it('exports a non-empty object', () => {
@@ -37,10 +38,26 @@ describe('EVENTS config', () => {
         expect(noTriggerEntries.length).toBeGreaterThan(0)
     })
 
+    it('every entry has a reactions array', () => {
+        for (const [key, config] of Object.entries(EVENTS)) {
+            expect(Array.isArray(config.reactions), `${key} missing reactions array`).toBe(true)
+        }
+    })
+
+    it('every reaction has a valid type', () => {
+        for (const [key, config] of Object.entries(EVENTS)) {
+            for (const reaction of config.reactions) {
+                expect(VALID_REACTION_TYPES.has(reaction.type), `${key} has unknown reaction type: ${reaction.type}`).toBe(true)
+            }
+        }
+    })
+
     it('timeout values are valid duration strings when present', () => {
         for (const [key, config] of Object.entries(EVENTS)) {
-            if (config.timeout !== undefined) {
-                expect(config.timeout, `${key} has invalid timeout format`).toMatch(/^\d+s$/)
+            for (const reaction of config.reactions) {
+                if ('timeout' in reaction && reaction.timeout !== undefined) {
+                    expect(reaction.timeout, `${key} reaction has invalid timeout format`).toMatch(/^\d+s$/)
+                }
             }
         }
     })


### PR DESCRIPTION
## Summary

- Replaces the flat reaction fields (`reply`, `image`, `sound`, `video`, `text`, `transition_in`, `transition_out`, `timeout`) on `EventConfig` with a typed `reactions: Reaction[]` array
- Each reaction carries its own fields — `image`, `video`, and `overlay_text` reactions each have independent `transition_in`, `transition_out`, and `timeout`
- `Handler.executeConfig` now iterates reactions and dispatches by type instead of checking flat fields
- `overlay/index.html` updated to render from the reactions array, applying per-reaction transitions
- All 9 existing events in `backend/config/events.ts` migrated to the new shape
- Tests updated throughout; 4 new test cases added

## Why

The old flat schema had a single set of `transition_in`/`transition_out`/`timeout` fields shared across all reaction types. An event with both an image and a video reaction had no way to configure them independently. This restructure is a prerequisite for #67 and #69.

## New types

```typescript
type Reaction =
  | { type: 'chat_reply';    message: string }
  | { type: 'overlay_text';  text: string; transition_in?: string; transition_out?: string; timeout?: string }
  | { type: 'image';         url: string; transition_in?: string; transition_out?: string; timeout?: string; offsetX?: number; offsetY?: number; offsetZ?: number }
  | { type: 'sound';         filename: string; volume?: number }
  | { type: 'video';         filename: string; transition_in?: string; transition_out?: string; timeout?: string; offsetX?: number; offsetY?: number; offsetZ?: number }
```

## Test plan

- [ ] All existing tests pass (2 pre-existing failures in `TwitchClient.test.ts` unrelated to this change)
- [ ] Overlay fires events correctly when backend broadcasts a reactions array
- [ ] Chat replies, sounds, images, videos, and overlay text all trigger as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)