### PR TITLE
[#67] Events page: list view

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -9,9 +9,12 @@ import { EVENTS } from './config/events.js';
 import Logger from './src/utils/Logger.js';
 import sessionStats from './src/SessionStats.js';
 import eventLog from './src/EventLog.js';
+import eventStorage from './src/EventStorage.js';
 import { wss, app } from './src/server.js';
 
 Logger.info('Starting Twitch project backend...');
+
+await eventStorage.load();
 
 let twitchClient: TwitchClient | null = null;
 let overlayBroadcasterService: OverlayBroadcasterService | null = null;
@@ -71,6 +74,19 @@ app.post('/api/log/:id/replay', async (req: Request, res: Response) => {
         return;
     }
     await eventRouter.route({ subscriptionType: entry.subscriptionType, event: entry.data }, true);
+    res.json({ ok: true });
+});
+
+app.get('/api/events', (_req: Request, res: Response) => {
+    res.json(eventStorage.getAll());
+});
+
+app.delete('/api/events/:name', async (req: Request, res: Response) => {
+    const deleted = await eventStorage.delete(req.params.name);
+    if (!deleted) {
+        res.status(404).json({ error: 'Event not found' });
+        return;
+    }
     res.json({ ok: true });
 });
 

--- a/backend/src/EventStorage.ts
+++ b/backend/src/EventStorage.ts
@@ -1,0 +1,49 @@
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import type { EventConfig } from './types.js';
+import { EVENTS } from '../config/events.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_PATH = join(__dirname, '../../data/events.json');
+
+export class EventStorage {
+    private events: Record<string, EventConfig> = {};
+    private loaded = false;
+
+    async load(): Promise<void> {
+        try {
+            const raw = await readFile(DATA_PATH, 'utf-8');
+            this.events = JSON.parse(raw);
+        } catch (err: unknown) {
+            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+            this.events = { ...EVENTS };
+            await this.persist();
+        }
+        this.loaded = true;
+    }
+
+    getAll(): EventConfig[] {
+        this.assertLoaded();
+        return Object.values(this.events);
+    }
+
+    async delete(name: string): Promise<boolean> {
+        this.assertLoaded();
+        if (!(name in this.events)) return false;
+        delete this.events[name];
+        await this.persist();
+        return true;
+    }
+
+    private async persist(): Promise<void> {
+        await mkdir(dirname(DATA_PATH), { recursive: true });
+        await writeFile(DATA_PATH, JSON.stringify(this.events, null, 2), 'utf-8');
+    }
+
+    private assertLoaded(): void {
+        if (!this.loaded) throw new Error('EventStorage: call load() before use');
+    }
+}
+
+export default new EventStorage();

--- a/frontend/src/components/EventRow.tsx
+++ b/frontend/src/components/EventRow.tsx
@@ -1,0 +1,90 @@
+import type { EventConfig, Reaction } from '../../../backend/src/types.js';
+
+const TYPE_COLORS: Record<string, string> = {
+  chat_command:               'var(--blue)',
+  chat_contains:              'var(--cyan)',
+  follow:                     'var(--green)',
+  subscription:               'var(--gold)',
+  raid:                       'var(--red)',
+  bits:                       'var(--gold)',
+  channel_points_redemption:  'var(--lilac)',
+};
+
+const PILL_LABELS: Partial<Record<Reaction['type'], string>> = {
+  chat_reply:   'reply',
+  image:        'image',
+  overlay_text: 'text',
+  sound:        'sound',
+  video:        'video',
+};
+
+interface Props {
+  event: EventConfig;
+  onDelete: (name: string) => void;
+}
+
+export default function EventRow({ event, onDelete }: Props) {
+  const badgeColor = TYPE_COLORS[event.event_type] ?? 'var(--muted)';
+  const pills = [...new Set(event.reactions.map(r => PILL_LABELS[r.type]).filter(Boolean))];
+
+  function handleDelete() {
+    if (!confirm(`Delete "${event.event_name}"?`)) return;
+    fetch(`/api/events/${encodeURIComponent(event.event_name)}`, { method: 'DELETE' })
+      .then(r => r.json())
+      .then(d => { if (d.ok) onDelete(event.event_name); })
+      .catch(() => {});
+  }
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 12,
+      padding: '10px 16px',
+      borderBottom: '1px solid var(--border)',
+    }}>
+      <span style={{ width: 220, flexShrink: 0, fontWeight: 600, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {event.event_name}
+      </span>
+
+      <span style={{
+        width: 140,
+        flexShrink: 0,
+        textAlign: 'center',
+        fontSize: 11,
+        fontWeight: 700,
+        padding: '3px 8px',
+        borderRadius: 4,
+        background: badgeColor + '22',
+        color: badgeColor,
+        border: `1px solid ${badgeColor}55`,
+        letterSpacing: '0.3px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}>
+        {event.event_type.replace(/_/g, ' ')}
+      </span>
+
+      <div style={{ display: 'flex', gap: 6, flex: 1, flexWrap: 'wrap' }}>
+        {pills.map(label => (
+          <span key={label} style={{
+            fontSize: 11,
+            fontWeight: 600,
+            padding: '2px 8px',
+            borderRadius: 4,
+            background: 'var(--border)',
+            color: 'var(--muted)',
+          }}>
+            {label}
+          </span>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+        <button className="btn btn-ghost btn-sm" disabled title="Coming in #69">Edit</button>
+        <button className="btn btn-danger btn-sm" onClick={handleDelete}>Delete</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -1,14 +1,37 @@
+import { useEffect, useState } from 'react';
+import type { EventConfig } from '../../../backend/src/types.js';
+import EventRow from '../components/EventRow.js';
+
 export default function EventsPage() {
+  const [events, setEvents] = useState<EventConfig[]>([]);
+
+  useEffect(() => {
+    fetch('/api/events')
+      .then(r => r.json() as Promise<EventConfig[]>)
+      .then(setEvents)
+      .catch(() => {});
+  }, []);
+
+  function handleDelete(name: string) {
+    setEvents(prev => prev.filter(e => e.event_name !== name));
+  }
+
   return (
-    <div style={{
-      background: 'var(--surface)',
-      border: '1px solid var(--border)',
-      borderRadius: 8,
-      padding: 24,
-      color: 'var(--muted)',
-      fontSize: 13,
-    }}>
-      Events
+    <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 16px 0' }}>
+        <span className="section-title">Events</span>
+        <button className="btn btn-primary btn-sm" disabled title="Coming in #69">+ New event</button>
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        {events.length === 0 ? (
+          <p style={{ color: 'var(--muted)', fontSize: 13, padding: '16px' }}>No events configured.</p>
+        ) : (
+          events.map(event => (
+            <EventRow key={event.event_name} event={event} onDelete={handleDelete} />
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/tests/EventStorage.test.ts
+++ b/tests/EventStorage.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { EventConfig } from '../backend/src/types.js'
+
+vi.mock('../backend/src/utils/Logger.js', () => ({
+    default: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), log: vi.fn() },
+}))
+
+const SEED: Record<string, EventConfig> = {
+    lurk: {
+        event_name: 'lurk',
+        event_type: 'channel_points_redemption',
+        trigger_on: ['lurk'],
+        reactions: [{ type: 'chat_reply', message: 'Thanks for lurking!' }],
+    },
+    follow: {
+        event_name: 'follow',
+        event_type: 'follow',
+        reactions: [{ type: 'chat_reply', message: 'Thanks for the follow!' }],
+    },
+}
+
+vi.mock('../backend/config/events.js', () => ({ EVENTS: SEED }))
+
+let diskData: string | null = null
+
+vi.mock('fs/promises', () => ({
+    readFile: vi.fn(async () => {
+        if (diskData === null) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+        return diskData
+    }),
+    writeFile: vi.fn(async (_path: string, content: string) => { diskData = content }),
+    mkdir: vi.fn(async () => {}),
+}))
+
+async function freshStorage() {
+    vi.resetModules()
+    const { EventStorage } = await import('../backend/src/EventStorage.js')
+    return new EventStorage()
+}
+
+describe('EventStorage', () => {
+    beforeEach(() => {
+        diskData = null
+        vi.clearAllMocks()
+    })
+
+    it('seeds from EVENTS config when no file exists', async () => {
+        const storage = await freshStorage()
+        await storage.load()
+        expect(storage.getAll()).toHaveLength(2)
+        expect(storage.getAll().map(e => e.event_name)).toContain('lurk')
+    })
+
+    it('writes events.json to disk on first load', async () => {
+        const { writeFile } = await import('fs/promises')
+        const storage = await freshStorage()
+        await storage.load()
+        expect(writeFile).toHaveBeenCalled()
+        expect(diskData).not.toBeNull()
+    })
+
+    it('loads from disk when file exists', async () => {
+        diskData = JSON.stringify({
+            custom: { event_name: 'custom', event_type: 'follow', reactions: [] },
+        })
+        const storage = await freshStorage()
+        await storage.load()
+        expect(storage.getAll()).toHaveLength(1)
+        expect(storage.getAll()[0].event_name).toBe('custom')
+    })
+
+    it('delete removes the event and returns true', async () => {
+        const storage = await freshStorage()
+        await storage.load()
+        const result = await storage.delete('lurk')
+        expect(result).toBe(true)
+        expect(storage.getAll().map(e => e.event_name)).not.toContain('lurk')
+    })
+
+    it('delete returns false for unknown event', async () => {
+        const storage = await freshStorage()
+        await storage.load()
+        const result = await storage.delete('nonexistent')
+        expect(result).toBe(false)
+    })
+
+    it('delete persists the change to disk', async () => {
+        const { writeFile } = await import('fs/promises')
+        const storage = await freshStorage()
+        await storage.load()
+        vi.clearAllMocks()
+        await storage.delete('lurk')
+        expect(writeFile).toHaveBeenCalled()
+    })
+
+    it('getAll throws if load() was not called', async () => {
+        const storage = await freshStorage()
+        expect(() => storage.getAll()).toThrow('load()')
+    })
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('../backend/src/server.js', () => ({
     wss: { clients: new Set(), on: vi.fn() },
-    app: { get: vi.fn(), post: vi.fn(), use: vi.fn() },
+    app: { get: vi.fn(), post: vi.fn(), delete: vi.fn(), use: vi.fn() },
     server: {}
+}))
+
+vi.mock('../backend/src/EventStorage.js', () => ({
+    default: { load: vi.fn().mockResolvedValue(undefined), getAll: vi.fn().mockReturnValue([]), delete: vi.fn().mockResolvedValue(true) }
 }))
 
 vi.mock('better-sqlite3', () => ({


### PR DESCRIPTION
## Summary

- `EventStorage` service reads/writes `data/events.json`, seeding from `backend/config/events.ts` on first run
- `GET /api/events` and `DELETE /api/events/:name` endpoints added to `backend/index.ts`
- `EventRow` component renders each event with: fixed-width name, coloured event type badge, reaction asset pills, and a Delete button with confirmation
- `EventsPage` replaces the placeholder with a live list fetched from the API; deletions remove the row immediately
- Edit and + New event buttons are present but disabled, wired up in #69

## UI changes

- Events page now shows all configured events in a scannable list
- Each row: event name → type badge (colour-coded) → pills for each reaction type (reply, sound, image, text, video) → Delete button
- Deleting an event shows a browser confirm then removes it from the list and the stored config

## Test plan
- [ ] All 9 default events appear in the list on load
- [ ] Delete removes the row and persists the change (confirm by restarting the server)
- [ ] `data/events.json` is created on first run if it doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)