### PR TITLE
[#69] Events page: create/edit modal with reactions builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,9 @@ backend/data/
 *.sqlite
 *.sqlite3
 
+# Runtime data directory (events.json, etc — managed locally)
+data/
+
 # Logs
 logs
 *.log

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -81,6 +81,29 @@ app.get('/api/events', (_req: Request, res: Response) => {
     res.json(eventStorage.getAll());
 });
 
+app.post('/api/events', async (req: Request, res: Response) => {
+    const config = req.body;
+    if (!config?.event_name || !config?.event_type) {
+        res.status(400).json({ error: 'event_name and event_type are required' });
+        return;
+    }
+    const created = await eventStorage.create(config);
+    if (!created) {
+        res.status(409).json({ error: 'Event already exists' });
+        return;
+    }
+    res.status(201).json({ ok: true });
+});
+
+app.put('/api/events/:name', async (req: Request, res: Response) => {
+    const updated = await eventStorage.update(req.params.name, req.body);
+    if (!updated) {
+        res.status(404).json({ error: 'Event not found' });
+        return;
+    }
+    res.json({ ok: true });
+});
+
 app.delete('/api/events/:name', async (req: Request, res: Response) => {
     const deleted = await eventStorage.delete(req.params.name);
     if (!deleted) {

--- a/backend/src/EventStorage.ts
+++ b/backend/src/EventStorage.ts
@@ -28,6 +28,22 @@ export class EventStorage {
         return Object.values(this.events);
     }
 
+    async create(config: EventConfig): Promise<boolean> {
+        this.assertLoaded();
+        if (config.event_name in this.events) return false;
+        this.events[config.event_name] = config;
+        await this.persist();
+        return true;
+    }
+
+    async update(name: string, config: EventConfig): Promise<boolean> {
+        this.assertLoaded();
+        if (!(name in this.events)) return false;
+        this.events[name] = config;
+        await this.persist();
+        return true;
+    }
+
     async delete(name: string): Promise<boolean> {
         this.assertLoaded();
         if (!(name in this.events)) return false;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -28,6 +28,7 @@ wss.on('connection', (ws) => {
     });
 });
 
+app.use(express.json());
 app.use('/overlay', express.static(join(__dirname, '../../overlay')));
 app.use('/assets', express.static(join(__dirname, '../../assets')));
 app.use('/dashboard', express.static(join(__dirname, '../../dist/dashboard')));

--- a/frontend/src/components/EventModal.tsx
+++ b/frontend/src/components/EventModal.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react';
+import type { EventConfig, Reaction } from '../../../backend/src/types.js';
+import ReactionCard, { defaultReaction } from './ReactionCard.js';
+
+const EVENT_TYPES = [
+  'chat_command',
+  'chat_contains',
+  'follow',
+  'subscription',
+  'raid',
+  'bits',
+  'channel_points_redemption',
+];
+
+const TRIGGER_REQUIRED = new Set(['chat_command', 'chat_contains', 'channel_points_redemption']);
+
+const TRIGGER_LABELS: Record<string, string> = {
+  chat_command:               'Commands (comma-separated, without !)',
+  chat_contains:              'Phrases (comma-separated)',
+  channel_points_redemption:  'Reward titles (comma-separated)',
+};
+
+const ALL_REACTION_TYPES: Reaction['type'][] = ['chat_reply', 'overlay_text', 'image', 'sound', 'video'];
+
+interface Props {
+  event: EventConfig | null; // null = create mode
+  onSave: (event: EventConfig) => void;
+  onClose: () => void;
+}
+
+interface FormState {
+  event_name: string;
+  event_type: string;
+  trigger_on: string;
+  reactions: Reaction[];
+}
+
+export default function EventModal({ event, onSave, onClose }: Props) {
+  const isCreate = event === null;
+
+  const [form, setForm] = useState<FormState>({
+    event_name:  event?.event_name  ?? '',
+    event_type:  event?.event_type  ?? 'chat_command',
+    trigger_on:  event?.trigger_on?.join(', ') ?? '',
+    reactions:   event?.reactions   ?? [],
+  });
+
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const usedTypes = new Set(form.reactions.map(r => r.type));
+  const availableTypes = ALL_REACTION_TYPES.filter(t => !usedTypes.has(t));
+
+  function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm(prev => ({ ...prev, [key]: value }));
+  }
+
+  function addReaction(type: Reaction['type']) {
+    setForm(prev => ({ ...prev, reactions: [...prev.reactions, defaultReaction(type)] }));
+    setAddMenuOpen(false);
+  }
+
+  function updateReaction(index: number, reaction: Reaction) {
+    setForm(prev => {
+      const reactions = [...prev.reactions];
+      reactions[index] = reaction;
+      return { ...prev, reactions };
+    });
+  }
+
+  function removeReaction(index: number) {
+    setForm(prev => ({ ...prev, reactions: prev.reactions.filter((_, i) => i !== index) }));
+  }
+
+  async function handleSave() {
+    if (!form.event_name.trim()) { setError('Event name is required'); return; }
+    if (!form.event_type)        { setError('Event type is required'); return; }
+
+    const config: EventConfig = {
+      event_name: form.event_name.trim(),
+      event_type: form.event_type,
+      reactions:  form.reactions,
+    };
+
+    if (TRIGGER_REQUIRED.has(form.event_type)) {
+      config.trigger_on = form.trigger_on.split(',').map(s => s.trim()).filter(Boolean);
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const url    = isCreate ? '/api/events' : `/api/events/${encodeURIComponent(event!.event_name)}`;
+      const method = isCreate ? 'POST' : 'PUT';
+      const res    = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error ?? 'Save failed'); return; }
+      onSave(config);
+    } catch {
+      setError('Network error');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.75)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="card" style={{ width: 560, height: '92vh', display: 'flex', flexDirection: 'column', padding: 0, overflow: 'hidden' }}>
+
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+          <span style={{ fontWeight: 700, fontSize: 15 }}>{isCreate ? 'New event' : `Edit: ${event!.event_name}`}</span>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 20, lineHeight: 1 }}>×</button>
+        </div>
+
+        {/* Fixed fields — event name, type, trigger */}
+        <div style={{ padding: '20px 20px 0', flexShrink: 0 }}>
+          <div className="field">
+            <label>EVENT NAME</label>
+            <input
+              value={form.event_name}
+              onChange={e => setField('event_name', e.target.value)}
+              placeholder="my_event"
+              disabled={!isCreate}
+              style={!isCreate ? { opacity: 0.5 } : {}}
+            />
+          </div>
+
+          <div className="field">
+            <label>EVENT TYPE</label>
+            <select value={form.event_type} onChange={e => setField('event_type', e.target.value)}>
+              {EVENT_TYPES.map(t => (
+                <option key={t} value={t}>{t.replace(/_/g, ' ')}</option>
+              ))}
+            </select>
+          </div>
+
+          {TRIGGER_REQUIRED.has(form.event_type) && (
+            <div className="field">
+              <label>{TRIGGER_LABELS[form.event_type]?.toUpperCase() ?? 'TRIGGER ON'}</label>
+              <input
+                value={form.trigger_on}
+                onChange={e => setField('trigger_on', e.target.value)}
+                placeholder={form.event_type === 'chat_command' ? 'lurk, hype' : form.event_type === 'chat_contains' ? 'gg, poggers' : 'My Reward'}
+              />
+            </div>
+          )}
+
+          {/* Reactions header + add button */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+            <span className="section-title">Reactions</span>
+            <div style={{ position: 'relative' }}>
+              <button
+                className="btn btn-ghost btn-sm"
+                onClick={() => setAddMenuOpen(o => !o)}
+                disabled={availableTypes.length === 0}
+              >+ Add reaction</button>
+              {addMenuOpen && (
+                <div style={{
+                  position: 'absolute', right: 0, top: '100%', marginTop: 4,
+                  background: 'var(--surface)', border: '1px solid var(--border)',
+                  borderRadius: 6, zIndex: 10, minWidth: 160, overflow: 'hidden',
+                }}>
+                  {availableTypes.map(t => (
+                    <button
+                      key={t}
+                      onClick={() => addReaction(t)}
+                      style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 14px', background: 'none', border: 'none', color: 'var(--text)', cursor: 'pointer', fontSize: 13 }}
+                      onMouseEnter={e => (e.currentTarget.style.background = 'var(--border)')}
+                      onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+                    >
+                      {t.replace(/_/g, ' ')}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Scrollable reactions list */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '0 20px' }}>
+          {form.reactions.length === 0 && (
+            <p style={{ color: 'var(--muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
+              No reactions yet. Add one above.
+            </p>
+          )}
+          {form.reactions.map((reaction, i) => (
+            <ReactionCard
+              key={`${reaction.type}-${i}`}
+              reaction={reaction}
+              usedTypes={usedTypes}
+              onChange={r => updateReaction(i, r)}
+              onRemove={() => removeReaction(i)}
+            />
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div style={{ padding: '14px 20px', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+          {error && <span style={{ color: 'var(--red)', fontSize: 13 }}>{error}</span>}
+          {!error && <span />}
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+            <button className="btn btn-primary" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/EventRow.tsx
+++ b/frontend/src/components/EventRow.tsx
@@ -20,10 +20,11 @@ const PILL_LABELS: Partial<Record<Reaction['type'], string>> = {
 
 interface Props {
   event: EventConfig;
+  onEdit: (event: EventConfig) => void;
   onDelete: (name: string) => void;
 }
 
-export default function EventRow({ event, onDelete }: Props) {
+export default function EventRow({ event, onEdit, onDelete }: Props) {
   const badgeColor = TYPE_COLORS[event.event_type] ?? 'var(--muted)';
   const pills = [...new Set(event.reactions.map(r => PILL_LABELS[r.type]).filter(Boolean))];
 
@@ -82,7 +83,7 @@ export default function EventRow({ event, onDelete }: Props) {
       </div>
 
       <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
-        <button className="btn btn-ghost btn-sm" disabled title="Coming in #69">Edit</button>
+        <button className="btn btn-ghost btn-sm" onClick={() => onEdit(event)}>Edit</button>
         <button className="btn btn-danger btn-sm" onClick={handleDelete}>Delete</button>
       </div>
     </div>

--- a/frontend/src/components/ReactionCard.tsx
+++ b/frontend/src/components/ReactionCard.tsx
@@ -1,0 +1,195 @@
+import type { Reaction } from '../../../backend/src/types.js';
+
+const ALL_REACTION_TYPES: Reaction['type'][] = ['chat_reply', 'overlay_text', 'image', 'sound', 'video'];
+
+const TYPE_LABELS: Record<Reaction['type'], string> = {
+  chat_reply:   'Chat Reply',
+  overlay_text: 'Overlay Text',
+  image:        'Image',
+  sound:        'Sound',
+  video:        'Video',
+};
+
+const TRANSITION_IN  = ['', 'fade-in', 'bounce-in', 'scale-in', 'slide-right-in', 'slide-left-in'];
+const TRANSITION_OUT = ['', 'fade-out', 'bounce-out', 'scale-out', 'slide-right-out', 'slide-left-out'];
+
+const TEMPLATE_HINT = '{{username}}, {{display_name}}, {{count}}';
+
+export function defaultReaction(type: Reaction['type']): Reaction {
+  switch (type) {
+    case 'chat_reply':   return { type: 'chat_reply', message: '' };
+    case 'overlay_text': return { type: 'overlay_text', text: '' };
+    case 'image':        return { type: 'image', url: '' };
+    case 'sound':        return { type: 'sound', filename: '' };
+    case 'video':        return { type: 'video', filename: '' };
+  }
+}
+
+interface Props {
+  reaction: Reaction;
+  usedTypes: Set<Reaction['type']>;
+  onChange: (r: Reaction) => void;
+  onRemove: () => void;
+}
+
+export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }: Props) {
+  const availableTypes = ALL_REACTION_TYPES.filter(t => t === reaction.type || !usedTypes.has(t));
+
+  function handleTypeChange(newType: Reaction['type']) {
+    onChange(defaultReaction(newType));
+  }
+
+  return (
+    <div className="card" style={{ padding: 14, marginBottom: 10, position: 'relative' }}>
+      <button
+        onClick={onRemove}
+        style={{ position: 'absolute', top: 10, right: 10, background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 16, lineHeight: 1 }}
+        title="Remove reaction"
+      >×</button>
+
+      <div className="field" style={{ marginBottom: 12 }}>
+        <label>TYPE</label>
+        <select value={reaction.type} onChange={e => handleTypeChange(e.target.value as Reaction['type'])}>
+          {availableTypes.map(t => <option key={t} value={t}>{TYPE_LABELS[t]}</option>)}
+        </select>
+      </div>
+
+      {reaction.type === 'chat_reply' && (
+        <div className="field" style={{ marginBottom: 0 }}>
+          <label>MESSAGE</label>
+          <input
+            value={reaction.message}
+            onChange={e => onChange({ ...reaction, message: e.target.value })}
+            placeholder="Your message here..."
+          />
+          <div className="field-hint">{TEMPLATE_HINT}</div>
+        </div>
+      )}
+
+      {reaction.type === 'overlay_text' && <>
+        <div className="field">
+          <label>TEXT</label>
+          <input
+            value={reaction.text}
+            onChange={e => onChange({ ...reaction, text: e.target.value })}
+            placeholder="Text to display..."
+          />
+          <div className="field-hint">{TEMPLATE_HINT}</div>
+        </div>
+        <TransitionFields reaction={reaction} onChange={onChange} />
+        <TimeoutField reaction={reaction} onChange={onChange} />
+      </>}
+
+      {reaction.type === 'image' && <>
+        <div className="field">
+          <label>URL</label>
+          <input
+            value={reaction.url}
+            onChange={e => onChange({ ...reaction, url: e.target.value })}
+            placeholder="lurk.png"
+          />
+        </div>
+        {reaction.url && (
+          <img
+            src={`/assets/img/${reaction.url}`}
+            alt="preview"
+            style={{ maxHeight: 80, maxWidth: '100%', borderRadius: 4, marginBottom: 12, objectFit: 'contain', background: 'var(--bg)' }}
+            onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+            onLoad={e => { (e.target as HTMLImageElement).style.display = 'block'; }}
+          />
+        )}
+        <OffsetFields reaction={reaction} onChange={onChange} />
+        <TransitionFields reaction={reaction} onChange={onChange} />
+        <TimeoutField reaction={reaction} onChange={onChange} />
+      </>}
+
+      {reaction.type === 'sound' && <>
+        <div className="field">
+          <label>FILENAME</label>
+          <input
+            value={reaction.filename}
+            onChange={e => onChange({ ...reaction, filename: e.target.value })}
+            placeholder="sound.mp3"
+          />
+        </div>
+        <div className="field" style={{ marginBottom: 0 }}>
+          <label>VOLUME (0–1)</label>
+          <input
+            type="number"
+            min={0} max={1} step={0.1}
+            value={reaction.volume ?? 0.5}
+            onChange={e => onChange({ ...reaction, volume: parseFloat(e.target.value) })}
+          />
+        </div>
+      </>}
+
+      {reaction.type === 'video' && <>
+        <div className="field">
+          <label>FILENAME</label>
+          <input
+            value={reaction.filename}
+            onChange={e => onChange({ ...reaction, filename: e.target.value })}
+            placeholder="video.mp4"
+          />
+        </div>
+        <OffsetFields reaction={reaction} onChange={onChange} />
+        <TransitionFields reaction={reaction} onChange={onChange} />
+        <TimeoutField reaction={reaction} onChange={onChange} />
+      </>}
+    </div>
+  );
+}
+
+type WithTransitions = { transition_in?: string; transition_out?: string };
+type WithTimeout     = { timeout?: string };
+type WithOffsets     = { offsetX?: number; offsetY?: number; offsetZ?: number };
+
+function TransitionFields<T extends WithTransitions>({ reaction, onChange }: { reaction: T; onChange: (r: T) => void }) {
+  return (
+    <div className="field-row" style={{ marginBottom: 12 }}>
+      <div className="field" style={{ marginBottom: 0 }}>
+        <label>TRANSITION IN</label>
+        <select value={reaction.transition_in ?? ''} onChange={e => onChange({ ...reaction, transition_in: e.target.value || undefined })}>
+          {TRANSITION_IN.map(t => <option key={t} value={t}>{t || '(none)'}</option>)}
+        </select>
+      </div>
+      <div className="field" style={{ marginBottom: 0 }}>
+        <label>TRANSITION OUT</label>
+        <select value={reaction.transition_out ?? ''} onChange={e => onChange({ ...reaction, transition_out: e.target.value || undefined })}>
+          {TRANSITION_OUT.map(t => <option key={t} value={t}>{t || '(none)'}</option>)}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+function TimeoutField<T extends WithTimeout>({ reaction, onChange }: { reaction: T; onChange: (r: T) => void }) {
+  return (
+    <div className="field" style={{ marginBottom: 0 }}>
+      <label>TIMEOUT</label>
+      <input
+        value={reaction.timeout ?? ''}
+        onChange={e => onChange({ ...reaction, timeout: e.target.value || undefined })}
+        placeholder="6s"
+      />
+      <div className="field-hint">e.g. 6s, 20s</div>
+    </div>
+  );
+}
+
+function OffsetFields<T extends WithOffsets>({ reaction, onChange }: { reaction: T; onChange: (r: T) => void }) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12, marginBottom: 12 }}>
+      {(['offsetX', 'offsetY', 'offsetZ'] as const).map(key => (
+        <div className="field" key={key} style={{ marginBottom: 0 }}>
+          <label>{key.toUpperCase()}</label>
+          <input
+            type="number"
+            value={reaction[key] ?? 0}
+            onChange={e => onChange({ ...reaction, [key]: parseInt(e.target.value, 10) || 0 })}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useState } from 'react';
 import type { EventConfig } from '../../../backend/src/types.js';
 import EventRow from '../components/EventRow.js';
+import EventModal from '../components/EventModal.js';
+
+// undefined = closed, null = create mode, EventConfig = edit mode
+type ModalState = EventConfig | null | undefined;
 
 export default function EventsPage() {
   const [events, setEvents] = useState<EventConfig[]>([]);
+  const [modal, setModal] = useState<ModalState>(undefined);
 
   useEffect(() => {
     fetch('/api/events')
@@ -16,22 +21,50 @@ export default function EventsPage() {
     setEvents(prev => prev.filter(e => e.event_name !== name));
   }
 
+  function handleSave(saved: EventConfig) {
+    setEvents(prev => {
+      const existing = prev.findIndex(e => e.event_name === saved.event_name);
+      if (existing >= 0) {
+        const next = [...prev];
+        next[existing] = saved;
+        return next;
+      }
+      return [...prev, saved];
+    });
+    setModal(undefined);
+  }
+
   return (
-    <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 16px 0' }}>
-        <span className="section-title">Events</span>
-        <button className="btn btn-primary btn-sm" disabled title="Coming in #69">+ New event</button>
+    <>
+      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 16px 0' }}>
+          <span className="section-title">Events</span>
+          <button className="btn btn-primary btn-sm" onClick={() => setModal(null)}>+ New event</button>
+        </div>
+
+        <div style={{ marginTop: 16 }}>
+          {events.length === 0 ? (
+            <p style={{ color: 'var(--muted)', fontSize: 13, padding: '16px' }}>No events configured.</p>
+          ) : (
+            events.map(event => (
+              <EventRow
+                key={event.event_name}
+                event={event}
+                onEdit={e => setModal(e)}
+                onDelete={handleDelete}
+              />
+            ))
+          )}
+        </div>
       </div>
 
-      <div style={{ marginTop: 16 }}>
-        {events.length === 0 ? (
-          <p style={{ color: 'var(--muted)', fontSize: 13, padding: '16px' }}>No events configured.</p>
-        ) : (
-          events.map(event => (
-            <EventRow key={event.event_name} event={event} onDelete={handleDelete} />
-          ))
-        )}
-      </div>
-    </div>
+      {modal !== undefined && (
+        <EventModal
+          event={modal}
+          onSave={handleSave}
+          onClose={() => setModal(undefined)}
+        />
+      )}
+    </>
   );
 }

--- a/tests/EventStorage.test.ts
+++ b/tests/EventStorage.test.ts
@@ -97,4 +97,59 @@ describe('EventStorage', () => {
         const storage = await freshStorage()
         expect(() => storage.getAll()).toThrow('load()')
     })
+
+    describe('create', () => {
+        it('adds a new event and returns true', async () => {
+            const storage = await freshStorage()
+            await storage.load()
+            const newEvent = { event_name: 'hype', event_type: 'chat_command', trigger_on: ['hype'], reactions: [] }
+            const result = await storage.create(newEvent)
+            expect(result).toBe(true)
+            expect(storage.getAll().map(e => e.event_name)).toContain('hype')
+        })
+
+        it('returns false when event name already exists', async () => {
+            const storage = await freshStorage()
+            await storage.load()
+            const duplicate = { event_name: 'lurk', event_type: 'chat_command', reactions: [] }
+            const result = await storage.create(duplicate)
+            expect(result).toBe(false)
+        })
+
+        it('persists new event to disk', async () => {
+            const { writeFile } = await import('fs/promises')
+            const storage = await freshStorage()
+            await storage.load()
+            vi.clearAllMocks()
+            await storage.create({ event_name: 'hype', event_type: 'chat_command', reactions: [] })
+            expect(writeFile).toHaveBeenCalled()
+        })
+    })
+
+    describe('update', () => {
+        it('updates an existing event and returns true', async () => {
+            const storage = await freshStorage()
+            await storage.load()
+            const updated = { event_name: 'lurk', event_type: 'follow', reactions: [] }
+            const result = await storage.update('lurk', updated)
+            expect(result).toBe(true)
+            expect(storage.getAll().find(e => e.event_name === 'lurk')?.event_type).toBe('follow')
+        })
+
+        it('returns false for unknown event', async () => {
+            const storage = await freshStorage()
+            await storage.load()
+            const result = await storage.update('nonexistent', { event_name: 'nonexistent', event_type: 'follow', reactions: [] })
+            expect(result).toBe(false)
+        })
+
+        it('persists updated event to disk', async () => {
+            const { writeFile } = await import('fs/promises')
+            const storage = await freshStorage()
+            await storage.load()
+            vi.clearAllMocks()
+            await storage.update('lurk', { event_name: 'lurk', event_type: 'follow', reactions: [] })
+            expect(writeFile).toHaveBeenCalled()
+        })
+    })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('../backend/src/server.js', () => ({
     wss: { clients: new Set(), on: vi.fn() },
-    app: { get: vi.fn(), post: vi.fn(), delete: vi.fn(), use: vi.fn() },
+    app: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), use: vi.fn() },
     server: {}
 }))
 
 vi.mock('../backend/src/EventStorage.js', () => ({
-    default: { load: vi.fn().mockResolvedValue(undefined), getAll: vi.fn().mockReturnValue([]), delete: vi.fn().mockResolvedValue(true) }
+    default: { load: vi.fn().mockResolvedValue(undefined), getAll: vi.fn().mockReturnValue([]), create: vi.fn().mockResolvedValue(true), update: vi.fn().mockResolvedValue(true), delete: vi.fn().mockResolvedValue(true) }
 }))
 
 vi.mock('better-sqlite3', () => ({

--- a/tests/src/server.test.ts
+++ b/tests/src/server.test.ts
@@ -14,8 +14,9 @@ vi.mock('http', () => ({
 
 vi.mock('express', () => {
     const app = { use: vi.fn(), get: vi.fn() }
-    const fn = vi.fn(() => app) as unknown as typeof import('express').default & { static: ReturnType<typeof vi.fn> }
+    const fn = vi.fn(() => app) as unknown as typeof import('express').default & { static: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> }
     fn.static = vi.fn()
+    fn.json = vi.fn(() => ({}))
     return { default: fn }
 })
 


### PR DESCRIPTION
## Summary

- `ReactionCard` component — per-reaction card with a type selector and dynamic fields; types: Chat Reply, Overlay Text, Image (with live preview), Sound, Video. Each visual reaction has its own transition in/out and timeout fields. Shared sub-components for transition selects, timeout, and offset (X/Y/Z) fields
- `EventModal` component — create/edit modal. Fixed fields (name, type, trigger_on) sit above a scrollable reactions list. Sends `POST /api/events` on create and `PUT /api/events/:name` on edit
- `EventStorage.create()` and `EventStorage.update()` — new methods persisted to `data/events.json`
- `POST /api/events` and `PUT /api/events/:name` endpoints added to `backend/index.ts`
- `express.json()` middleware added to `server.ts` so request bodies parse correctly
- `EventRow` Edit button now active — opens the modal pre-populated with the event's current data
- `EventsPage` "+ New event" button now opens a blank modal; saving inserts or updates the row in the list immediately

## UI changes

- Clicking **Edit** on any event row opens the modal with all fields and reactions pre-filled
- Clicking **+ New event** opens a blank modal
- Modal: name (disabled in edit mode) → type dropdown → conditional trigger field → scrollable reactions list with "+ Add reaction" dropdown
- Each reaction card has a type selector; changing type resets the card to defaults for that type; already-used types are hidden from the selector
- Image cards show a live `<img>` preview from `/assets/img/` as you type the filename
- Saving closes the modal and updates the list without a page reload

## Test plan
- [ ] Create a new event — appears in the list immediately
- [ ] Edit an existing event — changes reflected in the list
- [ ] Each reaction type renders its correct fields
- [ ] Trigger field shows/hides correctly per event type
- [ ] Saving with a blank event name shows an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)