### PR TITLE
[#62] Dashboard: viewers panel

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -5,12 +5,14 @@ import { type Request, type Response } from 'express';
 import { TwitchClient } from './src/twitch-client.js';
 import { EventRouter } from './src/EventRouter.js';
 import OverlayBroadcasterService from './src/services/OverlayBroadcasterService.js';
+import DashboardBroadcasterService from './src/services/DashboardBroadcasterService.js';
 import { EVENTS } from './config/events.js';
 import Logger from './src/utils/Logger.js';
 import sessionStats from './src/SessionStats.js';
 import eventLog from './src/EventLog.js';
 import eventStorage from './src/EventStorage.js';
-import { wss, app } from './src/server.js';
+import viewerTracker from './src/ViewerTracker.js';
+import { wss, dashboardWss, app } from './src/server.js';
 
 Logger.info('Starting Twitch project backend...');
 
@@ -18,10 +20,13 @@ await eventStorage.load();
 
 let twitchClient: TwitchClient | null = null;
 let overlayBroadcasterService: OverlayBroadcasterService | null = null;
+let dashboardBroadcasterService: DashboardBroadcasterService | null = null;
 let eventRouter: EventRouter | null = null;
 
 try {
     overlayBroadcasterService = new OverlayBroadcasterService(wss);
+    dashboardBroadcasterService = new DashboardBroadcasterService(dashboardWss);
+    viewerTracker.setDashboardBroadcaster(dashboardBroadcasterService);
 
     if (process.env.TWITCH_ACCESS_TOKEN && process.env.TWITCH_CLIENT_ID) {
         eventRouter = new EventRouter(null, overlayBroadcasterService);
@@ -38,6 +43,8 @@ try {
         });
 
         eventRouter.setTwitchClient(twitchClient);
+        viewerTracker.setTwitchClient(twitchClient);
+        void viewerTracker.startPolling();
 
         Logger.info('All services initialised');
     } else {
@@ -148,6 +155,10 @@ app.delete('/api/events/:name', async (req: Request, res: Response) => {
     res.json({ ok: true });
 });
 
+app.get('/api/viewers', (_req: Request, res: Response) => {
+    res.json(viewerTracker.getViewers());
+});
+
 app.get('/api/status', (_req: Request, res: Response) => {
     const twitchStatus = twitchClient?.getStatus() ?? {
         bot: { connected: false },
@@ -159,4 +170,4 @@ app.get('/api/status', (_req: Request, res: Response) => {
     });
 });
 
-export { twitchClient, overlayBroadcasterService, eventRouter };
+export { twitchClient, overlayBroadcasterService, dashboardBroadcasterService, eventRouter };

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -42,6 +42,7 @@ try {
             eventRouter
         });
 
+        await twitchClient.whenReady();
         eventRouter.setTwitchClient(twitchClient);
         viewerTracker.setTwitchClient(twitchClient);
         void viewerTracker.startPolling();

--- a/backend/src/EventRouter.ts
+++ b/backend/src/EventRouter.ts
@@ -90,7 +90,9 @@ export class EventRouter extends Handler {
             }
         }
 
-        if (!matched) {
+        if (matched) {
+            sessionStats.recordEventFired();
+        } else {
             Logger.info(`EventRouter: No match for "${rawEvent.subscriptionType}"`);
         }
     }

--- a/backend/src/EventRouter.ts
+++ b/backend/src/EventRouter.ts
@@ -8,6 +8,7 @@ import Logger from './utils/Logger.js';
 import type { EventConfig, TwitchRawEvent, TemplateData, ITwitchClient, IOverlayBroadcaster } from './types.js';
 import sessionStats from './SessionStats.js';
 import eventLog from './EventLog.js';
+import viewerTracker from './ViewerTracker.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -63,6 +64,7 @@ export class EventRouter extends Handler {
     async route(rawEvent: TwitchRawEvent, replay = false): Promise<void> {
         Logger.info(`EventRouter: Routing "${rawEvent.subscriptionType}"${replay ? ' (replay)' : ''}`);
         sessionStats.recordEvent(rawEvent.subscriptionType, rawEvent.event);
+        viewerTracker.recordEvent(rawEvent.subscriptionType, rawEvent.event);
 
         let matched = false;
         for (const eventType of this.eventTypes) {

--- a/backend/src/SessionStats.ts
+++ b/backend/src/SessionStats.ts
@@ -29,6 +29,9 @@ class SessionStats {
             case 'channel.raid':         this.raids++;     break;
             case 'channel.chat.message': this.chatMessages++; break;
         }
+    }
+
+    recordEventFired(): void {
         this.eventsFired++;
     }
 

--- a/backend/src/ViewerTracker.ts
+++ b/backend/src/ViewerTracker.ts
@@ -1,0 +1,104 @@
+import Logger from './utils/Logger.js';
+import type { IDashboardBroadcaster, ViewerData } from './types.js';
+
+interface ITwitchChattersClient {
+    getChatters(): Promise<{ userId: string; username: string }[]>
+}
+
+interface ViewerRecord {
+    username: string
+    firstSeen: number
+    messageCount: number
+}
+
+export class ViewerTracker {
+    private viewers = new Map<string, ViewerRecord>();
+    private twitchClient: ITwitchChattersClient | null = null;
+    private dashboardBroadcaster: IDashboardBroadcaster | null = null;
+    private pollInterval: ReturnType<typeof setInterval> | null = null;
+
+    setTwitchClient(client: ITwitchChattersClient): void {
+        this.twitchClient = client;
+    }
+
+    setDashboardBroadcaster(broadcaster: IDashboardBroadcaster): void {
+        this.dashboardBroadcaster = broadcaster;
+    }
+
+    async startPolling(): Promise<void> {
+        await this.syncViewers();
+        this.pollInterval = setInterval(() => void this.syncViewers(), 60_000);
+    }
+
+    stopPolling(): void {
+        if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = null;
+        }
+    }
+
+    recordEvent(subscriptionType: string, event: Record<string, unknown>): void {
+        if (subscriptionType === 'channel.stream.online') {
+            this.reset();
+            return;
+        }
+
+        if (subscriptionType === 'channel.chat.message') {
+            const userId = String(event['chatter_user_id'] ?? '');
+            const username = String(event['chatter_user_name'] ?? event['chatter_user_login'] ?? '');
+            if (!userId) return;
+
+            const now = Date.now();
+            const existing = this.viewers.get(userId);
+            if (existing) {
+                existing.messageCount++;
+                existing.username = username;
+            } else {
+                this.viewers.set(userId, { username, firstSeen: now, messageCount: 1 });
+            }
+
+            this.dashboardBroadcaster?.broadcast({ type: 'chat', userId, username });
+            Logger.debug(`ViewerTracker: chat from ${username}`);
+        }
+    }
+
+    reset(): void {
+        this.viewers.clear();
+        Logger.info('ViewerTracker: reset for new stream');
+    }
+
+    getViewers(): ViewerData[] {
+        const now = Date.now();
+        return Array.from(this.viewers.entries())
+            .map(([userId, record]) => ({
+                userId,
+                username: record.username,
+                watchTime: Math.floor((now - record.firstSeen) / 1000),
+                messageCount: record.messageCount,
+            }))
+            .sort((a, b) => b.watchTime - a.watchTime);
+    }
+
+    private async syncViewers(): Promise<void> {
+        if (!this.twitchClient) return;
+        const chatters = await this.twitchClient.getChatters();
+        const now = Date.now();
+        const activeIds = new Set(chatters.map(c => c.userId));
+
+        for (const { userId, username } of chatters) {
+            if (!this.viewers.has(userId)) {
+                this.viewers.set(userId, { username, firstSeen: now, messageCount: 0 });
+            }
+        }
+
+        for (const userId of this.viewers.keys()) {
+            if (!activeIds.has(userId)) {
+                this.viewers.delete(userId);
+            }
+        }
+
+        Logger.info(`ViewerTracker: synced ${chatters.length} chatters`);
+    }
+}
+
+export default new ViewerTracker();

--- a/backend/src/ViewerTracker.ts
+++ b/backend/src/ViewerTracker.ts
@@ -9,6 +9,9 @@ interface ViewerRecord {
     username: string
     firstSeen: number
     messageCount: number
+    bits: number
+    subs: number
+    pointsRedeemed: number
 }
 
 export class ViewerTracker {
@@ -54,12 +57,50 @@ export class ViewerTracker {
                 existing.messageCount++;
                 existing.username = username;
             } else {
-                this.viewers.set(userId, { username, firstSeen: now, messageCount: 1 });
+                this.viewers.set(userId, { username, firstSeen: now, messageCount: 1, bits: 0, subs: 0, pointsRedeemed: 0 });
             }
+
 
             this.dashboardBroadcaster?.broadcast({ type: 'chat', userId, username });
             Logger.debug(`ViewerTracker: chat from ${username}`);
+            return;
         }
+
+        if (subscriptionType === 'channel.cheer') {
+            if (event['is_anonymous']) return;
+            const userId = String(event['user_id'] ?? '');
+            const username = String(event['user_name'] ?? '');
+            const bits = Number(event['bits'] ?? 0);
+            if (!userId) return;
+            this.ensureViewer(userId, username).bits += bits;
+            return;
+        }
+
+        if (subscriptionType === 'channel.subscribe') {
+            const userId = String(event['user_id'] ?? '');
+            const username = String(event['user_name'] ?? '');
+            if (!userId) return;
+            this.ensureViewer(userId, username).subs++;
+            return;
+        }
+
+        if (subscriptionType === 'channel.channel_points_custom_reward_redemption.add') {
+            const userId = String(event['user_id'] ?? '');
+            const username = String(event['user_name'] ?? '');
+            if (!userId) return;
+            this.ensureViewer(userId, username).pointsRedeemed++;
+        }
+    }
+
+    private ensureViewer(userId: string, username: string): ViewerRecord {
+        const existing = this.viewers.get(userId);
+        if (existing) {
+            existing.username = username;
+            return existing;
+        }
+        const record: ViewerRecord = { username, firstSeen: Date.now(), messageCount: 0, bits: 0, subs: 0, pointsRedeemed: 0 };
+        this.viewers.set(userId, record);
+        return record;
     }
 
     reset(): void {
@@ -75,6 +116,9 @@ export class ViewerTracker {
                 username: record.username,
                 watchTime: Math.floor((now - record.firstSeen) / 1000),
                 messageCount: record.messageCount,
+                bits: record.bits,
+                subs: record.subs,
+                pointsRedeemed: record.pointsRedeemed,
             }))
             .sort((a, b) => b.watchTime - a.watchTime);
     }
@@ -87,7 +131,7 @@ export class ViewerTracker {
 
         for (const { userId, username } of chatters) {
             if (!this.viewers.has(userId)) {
-                this.viewers.set(userId, { username, firstSeen: now, messageCount: 0 });
+                this.viewers.set(userId, { username, firstSeen: now, messageCount: 0, bits: 0, subs: 0, pointsRedeemed: 0 });
             }
         }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,8 +12,19 @@ const app: Express = express();
 const PORT = 3001;
 
 const server: Server = createServer(app);
-const wss = new WebSocketServer({ server, path: '/ws/overlay' });
-const dashboardWss = new WebSocketServer({ server, path: '/ws/dashboard' });
+const wss = new WebSocketServer({ noServer: true });
+const dashboardWss = new WebSocketServer({ noServer: true });
+
+server.on('upgrade', (req, socket, head) => {
+    const pathname = req.url?.split('?')[0];
+    if (pathname === '/ws/overlay') {
+        wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
+    } else if (pathname === '/ws/dashboard') {
+        dashboardWss.handleUpgrade(req, socket, head, (ws) => dashboardWss.emit('connection', ws, req));
+    } else {
+        socket.destroy();
+    }
+});
 
 wss.on('connection', (ws) => {
     Logger.info('Overlay connected');

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,7 +12,8 @@ const app: Express = express();
 const PORT = 3001;
 
 const server: Server = createServer(app);
-const wss = new WebSocketServer({ server });
+const wss = new WebSocketServer({ server, path: '/ws/overlay' });
+const dashboardWss = new WebSocketServer({ server, path: '/ws/dashboard' });
 
 wss.on('connection', (ws) => {
     Logger.info('Overlay connected');
@@ -26,6 +27,11 @@ wss.on('connection', (ws) => {
     ws.on('close', () => {
         Logger.info('Overlay disconnected');
     });
+});
+
+dashboardWss.on('connection', (ws) => {
+    Logger.info('Dashboard connected');
+    ws.on('close', () => Logger.info('Dashboard disconnected'));
 });
 
 app.use(express.json());
@@ -46,4 +52,4 @@ server.listen(PORT, () => {
     Logger.info(`WebSocket server ready on ws://localhost:${PORT}`);
 });
 
-export { wss, app, server };
+export { wss, dashboardWss, app, server };

--- a/backend/src/services/DashboardBroadcasterService.ts
+++ b/backend/src/services/DashboardBroadcasterService.ts
@@ -1,0 +1,40 @@
+import { WebSocketServer, WebSocket as WsClient } from 'ws';
+import Logger from '../utils/Logger.js';
+import type { DashboardChatEvent, IDashboardBroadcaster } from '../types.js';
+
+export class DashboardBroadcasterService implements IDashboardBroadcaster {
+    private wss: WebSocketServer | null;
+
+    constructor(wss: WebSocketServer | null = null) {
+        this.wss = wss;
+    }
+
+    setWebSocketServer(wss: WebSocketServer): void {
+        this.wss = wss;
+    }
+
+    broadcast(event: DashboardChatEvent): void {
+        if (!this.wss) return;
+        const message = JSON.stringify(event);
+        this.wss.clients.forEach((client) => {
+            if (client.readyState === WsClient.OPEN) {
+                try {
+                    client.send(message);
+                } catch (error) {
+                    Logger.error('DashboardBroadcaster: Error sending to client:', error);
+                }
+            }
+        });
+    }
+
+    getClientCount(): number {
+        if (!this.wss) return 0;
+        let count = 0;
+        this.wss.clients.forEach((client) => {
+            if (client.readyState === WsClient.OPEN) count++;
+        });
+        return count;
+    }
+}
+
+export default DashboardBroadcasterService;

--- a/backend/src/twitch-client.ts
+++ b/backend/src/twitch-client.ts
@@ -22,6 +22,10 @@ interface TwitchSubscribeError {
     error?: string
 }
 
+interface TwitchChattersResponse {
+    data: { user_id: string; user_login: string; user_name: string }[]
+}
+
 export interface TwitchClientOptions {
     accessToken?: string
     broadcasterToken?: string
@@ -352,6 +356,25 @@ export class TwitchClient {
             const data = await res.json() as { total: number };
             return data.total ?? null;
         } catch { return null; }
+    }
+
+    async getChatters(): Promise<{ userId: string; username: string }[]> {
+        if (!this.channelId || !this.userId) return [];
+        try {
+            const res = await fetch(
+                `https://api.twitch.tv/helix/chat/chatters?broadcaster_id=${this.channelId}&moderator_id=${this.userId}`,
+                { headers: { 'Authorization': `Bearer ${this.accessToken}`, 'Client-Id': this.clientId } }
+            );
+            if (!res.ok) {
+                Logger.warn('TwitchClient: getChatters failed:', res.statusText);
+                return [];
+            }
+            const data = await res.json() as TwitchChattersResponse;
+            return data.data.map(c => ({ userId: c.user_id, username: c.user_name }));
+        } catch (error) {
+            Logger.error('TwitchClient: Error getting chatters:', error);
+            return [];
+        }
     }
 
     getStatus(): { bot: { connected: boolean }; broadcaster: { connected: boolean; configured: boolean } } {

--- a/backend/src/twitch-client.ts
+++ b/backend/src/twitch-client.ts
@@ -47,6 +47,7 @@ export class TwitchClient {
     private eventRouter: IEventRouter | null;
     private botSession: EventSubSession;
     private broadcasterSession: EventSubSession | null;
+    private initPromise: Promise<void>;
 
     constructor(options: TwitchClientOptions = {}) {
         const accessToken = options.accessToken ?? process.env.TWITCH_ACCESS_TOKEN;
@@ -82,7 +83,11 @@ export class TwitchClient {
             )
             : null;
 
-        this.init();
+        this.initPromise = this.init();
+    }
+
+    whenReady(): Promise<void> {
+        return this.initPromise;
     }
 
     async init(): Promise<void> {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -62,8 +62,27 @@ export interface OverlayEvent {
     reactions: OverlayReaction[]
 }
 
+export interface DashboardChatEvent {
+    type: 'chat'
+    userId: string
+    username: string
+}
+
+export interface IDashboardBroadcaster {
+    broadcast(event: DashboardChatEvent): void
+    getClientCount(): number
+}
+
+export interface ViewerData {
+    userId: string
+    username: string
+    watchTime: number
+    messageCount: number
+}
+
 export interface ITwitchClient {
     sendChatMessage(message: string): Promise<boolean>
+    getChatters(): Promise<{ userId: string; username: string }[]>
 }
 
 export interface IOverlayBroadcaster {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -78,6 +78,9 @@ export interface ViewerData {
     username: string
     watchTime: number
     messageCount: number
+    bits: number
+    subs: number
+    pointsRedeemed: number
 }
 
 export interface ITwitchClient {

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -42,9 +42,9 @@ function playBeep(userId: string): void {
             gain.connect(ctx.destination);
             osc.frequency.value = userFrequency(userId);
             gain.gain.setValueAtTime(0.08, ctx.currentTime);
-            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.62);
+            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.4);
             osc.start();
-            osc.stop(ctx.currentTime + 0.62);
+            osc.stop(ctx.currentTime + 0.4);
         });
     } catch { /* AudioContext unavailable */ }
 }

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from 'react';
+import { useViewers } from '../hooks/useViewers.ts';
+import { useDashboardSocket } from '../hooks/useDashboardSocket.ts';
+
+function formatWatchTime(seconds: number): string {
+    if (seconds < 60) return `${seconds}s`;
+    const mins = Math.floor(seconds / 60);
+    if (mins < 60) return `${mins}m`;
+    const hrs = Math.floor(mins / 60);
+    const rem = mins % 60;
+    return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`;
+}
+
+function playBeep(): void {
+    try {
+        const ctx = new AudioContext();
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.frequency.value = 880;
+        gain.gain.setValueAtTime(0.08, ctx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.12);
+        osc.onended = () => ctx.close();
+    } catch { /* AudioContext unavailable */ }
+}
+
+export default function ViewersPanel() {
+    const viewers = useViewers();
+    const flash = useDashboardSocket();
+    const [flashing, setFlashing] = useState<Set<string>>(new Set());
+    const prevFlash = useRef<ChatFlash | null>(null);
+
+    useEffect(() => {
+        if (!flash || flash === prevFlash.current) return;
+        prevFlash.current = flash;
+
+        playBeep();
+
+        setFlashing(prev => new Set(prev).add(flash.userId));
+        const timeout = setTimeout(() => {
+            setFlashing(prev => {
+                const next = new Set(prev);
+                next.delete(flash.userId);
+                return next;
+            });
+        }, 2000);
+
+        return () => clearTimeout(timeout);
+    }, [flash]);
+
+    return (
+        <div style={{
+            background: 'var(--surface)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: 24,
+        }}>
+            <h3 style={{ margin: '0 0 16px', fontSize: 14, fontWeight: 600, color: 'var(--text)' }}>
+                Viewers ({viewers.length})
+            </h3>
+            {viewers.length === 0 ? (
+                <p style={{ color: 'var(--muted)', fontSize: 13, margin: 0 }}>No viewers yet</p>
+            ) : (
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+                    <thead>
+                        <tr style={{ color: 'var(--muted)', textAlign: 'left' }}>
+                            <th style={{ paddingBottom: 8, fontWeight: 500 }}>Username</th>
+                            <th style={{ paddingBottom: 8, fontWeight: 500 }}>Watching for</th>
+                            <th style={{ paddingBottom: 8, fontWeight: 500, textAlign: 'right' }}>Messages</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {viewers.map(viewer => (
+                            <tr
+                                key={viewer.userId}
+                                style={{
+                                    color: flashing.has(viewer.userId) ? '#4ade80' : 'var(--text)',
+                                    transition: 'color 0.3s ease',
+                                    borderTop: '1px solid var(--border)',
+                                }}
+                            >
+                                <td style={{ padding: '6px 0' }}>{viewer.username}</td>
+                                <td style={{ padding: '6px 0' }}>{formatWatchTime(viewer.watchTime)}</td>
+                                <td style={{ padding: '6px 0', textAlign: 'right' }}>{viewer.messageCount}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+}
+
+interface ChatFlash {
+    userId: string
+    username: string
+}

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { useViewers } from '../hooks/useViewers.ts';
 import { useDashboardSocket } from '../hooks/useDashboardSocket.ts';
+import type { Viewer } from '../hooks/useViewers.ts';
+
+interface ChatFlash {
+    userId: string
+    username: string
+}
 
 function formatWatchTime(seconds: number): string {
     if (seconds < 60) return `${seconds}s`;
@@ -11,28 +16,45 @@ function formatWatchTime(seconds: number): string {
     return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`;
 }
 
+let sharedAudioCtx: AudioContext | null = null;
+
 function playBeep(): void {
     try {
-        const ctx = new AudioContext();
-        const osc = ctx.createOscillator();
-        const gain = ctx.createGain();
-        osc.connect(gain);
-        gain.connect(ctx.destination);
-        osc.frequency.value = 880;
-        gain.gain.setValueAtTime(0.08, ctx.currentTime);
-        gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12);
-        osc.start();
-        osc.stop(ctx.currentTime + 0.12);
-        osc.onended = () => ctx.close();
+        sharedAudioCtx ??= new AudioContext();
+        void sharedAudioCtx.resume().then(() => {
+            const ctx = sharedAudioCtx!;
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.connect(gain);
+            gain.connect(ctx.destination);
+            osc.frequency.value = 880;
+            gain.gain.setValueAtTime(0.08, ctx.currentTime);
+            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12);
+            osc.start();
+            osc.stop(ctx.currentTime + 0.12);
+        });
     } catch { /* AudioContext unavailable */ }
 }
 
 export default function ViewersPanel() {
-    const viewers = useViewers();
+    const [viewers, setViewers] = useState<Viewer[]>([]);
     const flash = useDashboardSocket();
     const [flashing, setFlashing] = useState<Set<string>>(new Set());
     const prevFlash = useRef<ChatFlash | null>(null);
 
+    // Base poll — syncs the full list from the server
+    useEffect(() => {
+        const load = () =>
+            fetch('/api/viewers')
+                .then(r => r.json() as Promise<Viewer[]>)
+                .then(setViewers)
+                .catch(() => {});
+        load();
+        const id = setInterval(load, 30_000);
+        return () => clearInterval(id);
+    }, []);
+
+    // Real-time update — increment count immediately on WS event
     useEffect(() => {
         if (!flash || flash === prevFlash.current) return;
         prevFlash.current = flash;
@@ -47,6 +69,18 @@ export default function ViewersPanel() {
                 return next;
             });
         }, 2000);
+
+        setViewers(prev => {
+            const exists = prev.some(v => v.userId === flash.userId);
+            if (exists) {
+                return prev.map(v =>
+                    v.userId === flash.userId
+                        ? { ...v, messageCount: v.messageCount + 1 }
+                        : v
+                );
+            }
+            return [...prev, { userId: flash.userId, username: flash.username, watchTime: 0, messageCount: 1 }];
+        });
 
         return () => clearTimeout(timeout);
     }, [flash]);
@@ -92,9 +126,4 @@ export default function ViewersPanel() {
             )}
         </div>
     );
-}
-
-interface ChatFlash {
-    userId: string
-    username: string
 }

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -42,9 +42,9 @@ function playBeep(userId: string): void {
             gain.connect(ctx.destination);
             osc.frequency.value = userFrequency(userId);
             gain.gain.setValueAtTime(0.08, ctx.currentTime);
-            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12);
+            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.62);
             osc.start();
-            osc.stop(ctx.currentTime + 0.12);
+            osc.stop(ctx.currentTime + 0.62);
         });
     } catch { /* AudioContext unavailable */ }
 }

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -42,9 +42,9 @@ function playBeep(userId: string): void {
             gain.connect(ctx.destination);
             osc.frequency.value = userFrequency(userId);
             gain.gain.setValueAtTime(0.08, ctx.currentTime);
-            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.4);
+            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
             osc.start();
-            osc.stop(ctx.currentTime + 0.4);
+            osc.stop(ctx.currentTime + 0.5);
         });
     } catch { /* AudioContext unavailable */ }
 }

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -16,13 +16,17 @@ function formatWatchTime(seconds: number): string {
     return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`;
 }
 
-// Pentatonic scale across two octaves — any combination sounds pleasant
-const PENTATONIC_HZ = [261.63, 293.66, 329.63, 392.00, 440.00, 523.25, 587.33, 659.25, 784.00, 880.00];
+// 5 pentatonic ratios × 4 octaves = 20 unique pitches, all musically consonant
+const PENTATONIC_RATIOS = [1, 1.125, 1.25, 1.5, 1.667];
+const BASE_FREQ = 130.81; // C3
+const OCTAVES = 4;
 
 function userFrequency(userId: string): number {
     let hash = 0;
     for (const ch of userId) hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
-    return PENTATONIC_HZ[hash % PENTATONIC_HZ.length];
+    const note   = hash % PENTATONIC_RATIOS.length;
+    const octave = (hash >>> 8) % OCTAVES;
+    return BASE_FREQ * PENTATONIC_RATIOS[note] * Math.pow(2, octave);
 }
 
 let sharedAudioCtx: AudioContext | null = null;

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -92,7 +92,7 @@ export default function ViewersPanel() {
                         : v
                 );
             }
-            return [...prev, { userId: flash.userId, username: flash.username, watchTime: 0, messageCount: 1 }];
+            return [...prev, { userId: flash.userId, username: flash.username, watchTime: 0, messageCount: 1, bits: 0, subs: 0, pointsRedeemed: 0 }];
         });
 
         return () => clearTimeout(timeout);
@@ -116,7 +116,10 @@ export default function ViewersPanel() {
                         <tr style={{ color: 'var(--muted)', textAlign: 'left' }}>
                             <th style={{ paddingBottom: 8, fontWeight: 500 }}>Username</th>
                             <th style={{ paddingBottom: 8, fontWeight: 500 }}>Watching for</th>
-                            <th style={{ paddingBottom: 8, fontWeight: 500, textAlign: 'right' }}>Messages</th>
+                            <th style={{ paddingBottom: 8, fontWeight: 500, textAlign: 'right' }}>Msgs</th>
+                            <th style={{ paddingBottom: 8, fontWeight: 500, textAlign: 'right' }}>Bits</th>
+                            <th style={{ paddingBottom: 8, fontWeight: 500, textAlign: 'right' }}>Subs</th>
+                            <th style={{ paddingBottom: 8, fontWeight: 500, textAlign: 'right' }}>Points</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -132,6 +135,9 @@ export default function ViewersPanel() {
                                 <td style={{ padding: '6px 0' }}>{viewer.username}</td>
                                 <td style={{ padding: '6px 0' }}>{formatWatchTime(viewer.watchTime)}</td>
                                 <td style={{ padding: '6px 0', textAlign: 'right' }}>{viewer.messageCount}</td>
+                                <td style={{ padding: '6px 0', textAlign: 'right' }}>{viewer.bits.toLocaleString()}</td>
+                                <td style={{ padding: '6px 0', textAlign: 'right' }}>{viewer.subs}</td>
+                                <td style={{ padding: '6px 0', textAlign: 'right' }}>{viewer.pointsRedeemed.toLocaleString()}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -16,9 +16,18 @@ function formatWatchTime(seconds: number): string {
     return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`;
 }
 
+// Pentatonic scale across two octaves — any combination sounds pleasant
+const PENTATONIC_HZ = [261.63, 293.66, 329.63, 392.00, 440.00, 523.25, 587.33, 659.25, 784.00, 880.00];
+
+function userFrequency(userId: string): number {
+    let hash = 0;
+    for (const ch of userId) hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
+    return PENTATONIC_HZ[hash % PENTATONIC_HZ.length];
+}
+
 let sharedAudioCtx: AudioContext | null = null;
 
-function playBeep(): void {
+function playBeep(userId: string): void {
     try {
         sharedAudioCtx ??= new AudioContext();
         void sharedAudioCtx.resume().then(() => {
@@ -27,7 +36,7 @@ function playBeep(): void {
             const gain = ctx.createGain();
             osc.connect(gain);
             gain.connect(ctx.destination);
-            osc.frequency.value = 880;
+            osc.frequency.value = userFrequency(userId);
             gain.gain.setValueAtTime(0.08, ctx.currentTime);
             gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12);
             osc.start();
@@ -59,7 +68,7 @@ export default function ViewersPanel() {
         if (!flash || flash === prevFlash.current) return;
         prevFlash.current = flash;
 
-        playBeep();
+        playBeep(flash.userId);
 
         setFlashing(prev => new Set(prev).add(flash.userId));
         const timeout = setTimeout(() => {

--- a/frontend/src/components/ViewersPanel.tsx
+++ b/frontend/src/components/ViewersPanel.tsx
@@ -41,7 +41,7 @@ function playBeep(userId: string): void {
             osc.connect(gain);
             gain.connect(ctx.destination);
             osc.frequency.value = userFrequency(userId);
-            gain.gain.setValueAtTime(0.08, ctx.currentTime);
+            gain.gain.setValueAtTime(0.2, ctx.currentTime);
             gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
             osc.start();
             osc.stop(ctx.currentTime + 0.5);

--- a/frontend/src/hooks/useDashboardSocket.ts
+++ b/frontend/src/hooks/useDashboardSocket.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export interface ChatFlash {
+    userId: string
+    username: string
+}
+
+export function useDashboardSocket(): ChatFlash | null {
+    const [flash, setFlash] = useState<ChatFlash | null>(null);
+
+    useEffect(() => {
+        const wsUrl = `ws://${window.location.host}/ws/dashboard`;
+        const ws = new WebSocket(wsUrl);
+
+        ws.onmessage = (e) => {
+            try {
+                const event = JSON.parse(e.data as string) as { type: string; userId: string; username: string };
+                if (event.type === 'chat') {
+                    setFlash({ userId: event.userId, username: event.username });
+                }
+            } catch { /* ignore malformed messages */ }
+        };
+
+        return () => ws.close();
+    }, []);
+
+    return flash;
+}

--- a/frontend/src/hooks/useViewers.ts
+++ b/frontend/src/hooks/useViewers.ts
@@ -5,6 +5,9 @@ export interface Viewer {
     username: string
     watchTime: number
     messageCount: number
+    bits: number
+    subs: number
+    pointsRedeemed: number
 }
 
 export function useViewers(): Viewer[] {

--- a/frontend/src/hooks/useViewers.ts
+++ b/frontend/src/hooks/useViewers.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export interface Viewer {
+    userId: string
+    username: string
+    watchTime: number
+    messageCount: number
+}
+
+export function useViewers(): Viewer[] {
+    const [viewers, setViewers] = useState<Viewer[]>([]);
+
+    useEffect(() => {
+        const load = () =>
+            fetch('/api/viewers')
+                .then(r => r.json() as Promise<Viewer[]>)
+                .then(setViewers)
+                .catch(() => {});
+
+        load();
+        const id = setInterval(load, 30_000);
+        return () => clearInterval(id);
+    }, []);
+
+    return viewers;
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import StreamStatsPanel from '../components/StreamStatsPanel.tsx';
 import EventLogSidebar from '../components/EventLogSidebar.tsx';
+import ViewersPanel from '../components/ViewersPanel.tsx';
 
 function useIsLive(): boolean {
   const [isLive, setIsLive] = useState(false);
@@ -32,7 +33,7 @@ export default function DashboardPage() {
     }}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
         <StreamStatsPanel />
-        <Placeholder label="Viewers" />
+        <ViewersPanel />
       </div>
 
       {isLive && (
@@ -44,17 +45,3 @@ export default function DashboardPage() {
   );
 }
 
-function Placeholder({ label }: { label: string }) {
-  return (
-    <div style={{
-      background: 'var(--surface)',
-      border: '1px solid var(--border)',
-      borderRadius: 8,
-      padding: 24,
-      color: 'var(--muted)',
-      fontSize: 13,
-    }}>
-      {label}
-    </div>
-  );
-}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': 'http://localhost:3001',
+      '/ws': { target: 'ws://localhost:3001', ws: true },
     },
   },
 });

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -218,7 +218,7 @@
             connect() {
                 try {
                     // Connect to the backend WebSocket server
-                    this.ws = new WebSocket('ws://localhost:3001');
+                    this.ws = new WebSocket('ws://localhost:3001/ws/overlay');
 
                     this.ws.onopen = () => {
                         console.log('Connected to Twitch backend');

--- a/tests/SessionStats.test.ts
+++ b/tests/SessionStats.test.ts
@@ -44,11 +44,11 @@ describe('SessionStats', () => {
             expect(sessionStats.snapshot().chatMessages).toBe(2)
         })
 
-        it('increments eventsFired for every matched event', () => {
+        it('does NOT increment eventsFired — that is done via recordEventFired()', () => {
             sessionStats.recordEvent('channel.follow', {})
             sessionStats.recordEvent('channel.subscribe', {})
             sessionStats.recordEvent('channel.cheer', { bits: 100 })
-            expect(sessionStats.snapshot().eventsFired).toBe(3)
+            expect(sessionStats.snapshot().eventsFired).toBe(0)
         })
 
         it('does NOT increment eventsFired for channel.stream.online', () => {
@@ -80,9 +80,24 @@ describe('SessionStats', () => {
         })
     })
 
+    describe('recordEventFired', () => {
+        it('increments eventsFired', () => {
+            sessionStats.recordEventFired()
+            sessionStats.recordEventFired()
+            expect(sessionStats.snapshot().eventsFired).toBe(2)
+        })
+
+        it('is reset by channel.stream.online', () => {
+            sessionStats.recordEventFired()
+            sessionStats.recordEvent('channel.stream.online', {})
+            expect(sessionStats.snapshot().eventsFired).toBe(0)
+        })
+    })
+
     describe('snapshot', () => {
         it('returns a copy of current counters', () => {
             sessionStats.recordEvent('channel.follow', {})
+            sessionStats.recordEventFired()
             const snap = sessionStats.snapshot()
             expect(snap).toEqual({ follows: 1, subs: 0, bits: 0, chatMessages: 0, eventsFired: 1, raids: 0 })
         })

--- a/tests/TwitchClient.test.ts
+++ b/tests/TwitchClient.test.ts
@@ -168,20 +168,17 @@ describe('TwitchClient', () => {
             const client = new TwitchClient({ accessToken: 'tok', clientId: 'cid', eventRouter })
             await new Promise(r => setTimeout(r, 0))
 
-            const message = {
-                metadata: { message_type: 'notification' },
-                payload: {
-                    subscription: { type: 'channel.chat.message' },
-                    event: { chatter_user_id: 'user-999', message: { text: '!lurk' } },
-                },
+            const notification = {
+                subscriptionType: 'channel.chat.message',
+                event: { chatter_user_id: 'user-999', message: { text: '!lurk' } },
             }
 
-            client.handleNotification(message as Parameters<typeof client.handleNotification>[0])
+            client.handleNotification(notification)
 
             expect(eventRouter.route).toHaveBeenCalledOnce()
             const routed = (eventRouter.route as ReturnType<typeof vi.fn>).mock.calls[0][0] as TwitchRawEvent
             expect(routed.subscriptionType).toBe('channel.chat.message')
-            expect(routed.event).toEqual(message.payload.event)
+            expect(routed.event).toEqual(notification.event)
         })
 
         it("skips the bot's own chat messages", async () => {
@@ -191,15 +188,12 @@ describe('TwitchClient', () => {
             await new Promise(r => setTimeout(r, 0))
 
             // The bot's own userId was set to 'user-123' by the mocked getUserId response
-            const message = {
-                metadata: { message_type: 'notification' },
-                payload: {
-                    subscription: { type: 'channel.chat.message' },
-                    event: { chatter_user_id: 'user-123' }, // same as bot userId
-                },
+            const notification = {
+                subscriptionType: 'channel.chat.message',
+                event: { chatter_user_id: 'user-123' }, // same as bot userId
             }
 
-            client.handleNotification(message as Parameters<typeof client.handleNotification>[0])
+            client.handleNotification(notification)
 
             expect(eventRouter.route).not.toHaveBeenCalled()
         })
@@ -209,18 +203,13 @@ describe('TwitchClient', () => {
             const client = new TwitchClient({ accessToken: 'tok', clientId: 'cid' })
             await new Promise(r => setTimeout(r, 0))
 
-            const message = {
-                metadata: { message_type: 'notification' },
-                payload: {
-                    subscription: { type: 'channel.follow' },
-                    event: { user_id: 'follower-1' },
-                },
+            const notification = {
+                subscriptionType: 'channel.follow',
+                event: { user_id: 'follower-1' },
             }
 
             // Should not throw
-            expect(() =>
-                client.handleNotification(message as Parameters<typeof client.handleNotification>[0])
-            ).not.toThrow()
+            expect(() => client.handleNotification(notification)).not.toThrow()
         })
 
         it('routes non-chat events regardless of user id', async () => {
@@ -229,15 +218,12 @@ describe('TwitchClient', () => {
             const client = new TwitchClient({ accessToken: 'tok', clientId: 'cid', eventRouter })
             await new Promise(r => setTimeout(r, 0))
 
-            const message = {
-                metadata: { message_type: 'notification' },
-                payload: {
-                    subscription: { type: 'channel.follow' },
-                    event: { user_id: 'user-123' }, // same id but different event type — should NOT be filtered
-                },
+            const notification = {
+                subscriptionType: 'channel.follow',
+                event: { user_id: 'user-123' }, // same id but different event type — should NOT be filtered
             }
 
-            client.handleNotification(message as Parameters<typeof client.handleNotification>[0])
+            client.handleNotification(notification)
 
             expect(eventRouter.route).toHaveBeenCalledOnce()
         })

--- a/tests/ViewerTracker.test.ts
+++ b/tests/ViewerTracker.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { ViewerTracker } from '../backend/src/ViewerTracker.js'
+import type { IDashboardBroadcaster, DashboardChatEvent } from '../backend/src/types.js'
+
+vi.mock('../backend/src/utils/Logger.js', () => ({
+    default: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), log: vi.fn() },
+}))
+
+function makeBroadcaster(): IDashboardBroadcaster & { events: DashboardChatEvent[] } {
+    const events: DashboardChatEvent[] = []
+    return {
+        events,
+        broadcast: vi.fn((e: DashboardChatEvent) => events.push(e)),
+        getClientCount: vi.fn(() => 0),
+    }
+}
+
+function makeTwitchClient(chatters: { userId: string; username: string }[] = []) {
+    return { getChatters: vi.fn().mockResolvedValue(chatters) }
+}
+
+describe('ViewerTracker', () => {
+    let tracker: ViewerTracker
+    let broadcaster: ReturnType<typeof makeBroadcaster>
+
+    beforeEach(() => {
+        tracker = new ViewerTracker()
+        broadcaster = makeBroadcaster()
+        tracker.setDashboardBroadcaster(broadcaster)
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        tracker.stopPolling()
+        vi.useRealTimers()
+    })
+
+    describe('recordEvent – chat message', () => {
+        it('adds a new viewer on first message', () => {
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            const viewers = tracker.getViewers()
+            expect(viewers).toHaveLength(1)
+            expect(viewers[0].username).toBe('Alice')
+            expect(viewers[0].messageCount).toBe(1)
+        })
+
+        it('increments messageCount for subsequent messages', () => {
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            expect(tracker.getViewers()[0].messageCount).toBe(2)
+        })
+
+        it('tracks multiple distinct viewers', () => {
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u2', chatter_user_name: 'Bob' })
+            expect(tracker.getViewers()).toHaveLength(2)
+        })
+
+        it('broadcasts a chat event to the dashboard', () => {
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            expect(broadcaster.broadcast).toHaveBeenCalledWith({ type: 'chat', userId: 'u1', username: 'Alice' })
+        })
+
+        it('does nothing when chatter_user_id is missing', () => {
+            tracker.recordEvent('channel.chat.message', {})
+            expect(tracker.getViewers()).toHaveLength(0)
+            expect(broadcaster.broadcast).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('recordEvent – stream online', () => {
+        it('clears all viewers on channel.stream.online', () => {
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            tracker.recordEvent('channel.stream.online', {})
+            expect(tracker.getViewers()).toHaveLength(0)
+        })
+    })
+
+    describe('getViewers', () => {
+        it('sorts viewers by watch time descending', () => {
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            vi.advanceTimersByTime(10_000)
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u2', chatter_user_name: 'Bob' })
+
+            const viewers = tracker.getViewers()
+            expect(viewers[0].username).toBe('Alice')
+            expect(viewers[1].username).toBe('Bob')
+        })
+
+        it('returns watchTime in seconds since firstSeen', () => {
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            vi.advanceTimersByTime(5_000)
+            expect(tracker.getViewers()[0].watchTime).toBe(5)
+        })
+    })
+
+    describe('startPolling', () => {
+        it('syncs viewers immediately on start', async () => {
+            const client = makeTwitchClient([{ userId: 'u1', username: 'Alice' }])
+            tracker.setTwitchClient(client)
+            await tracker.startPolling()
+            expect(client.getChatters).toHaveBeenCalledOnce()
+            expect(tracker.getViewers()).toHaveLength(1)
+        })
+
+        it('adds viewers from getChatters with messageCount 0', async () => {
+            const client = makeTwitchClient([{ userId: 'u1', username: 'Alice' }])
+            tracker.setTwitchClient(client)
+            await tracker.startPolling()
+            expect(tracker.getViewers()[0].messageCount).toBe(0)
+        })
+
+        it('removes viewers who are no longer in chatters list', async () => {
+            tracker.recordEvent('channel.chat.message', { chatter_user_id: 'u1', chatter_user_name: 'Alice' })
+            const client = makeTwitchClient([])
+            tracker.setTwitchClient(client)
+            await tracker.startPolling()
+            expect(tracker.getViewers()).toHaveLength(0)
+        })
+
+        it('polls again after 60 seconds', async () => {
+            const client = makeTwitchClient([])
+            tracker.setTwitchClient(client)
+            await tracker.startPolling()
+            vi.advanceTimersByTime(60_000)
+            await Promise.resolve()
+            await Promise.resolve()
+            expect(client.getChatters).toHaveBeenCalledTimes(2)
+        })
+
+        it('does nothing when twitchClient is not set', async () => {
+            await tracker.startPolling()
+            expect(tracker.getViewers()).toHaveLength(0)
+        })
+    })
+})

--- a/tests/services/DashboardBroadcasterService.test.ts
+++ b/tests/services/DashboardBroadcasterService.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { WebSocket as WsClient } from 'ws'
+import { DashboardBroadcasterService } from '../../backend/src/services/DashboardBroadcasterService.js'
+import type { DashboardChatEvent } from '../../backend/src/types.js'
+
+vi.mock('../../backend/src/utils/Logger.js', () => ({
+    default: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), log: vi.fn() },
+}))
+
+function makeClient(readyState: number) {
+    return { readyState, send: vi.fn() } as unknown as WsClient
+}
+
+function makeWss(clients: WsClient[]) {
+    return { clients: new Set(clients) } as unknown as import('ws').WebSocketServer
+}
+
+const sampleEvent: DashboardChatEvent = { type: 'chat', userId: 'u1', username: 'Alice' }
+
+describe('DashboardBroadcasterService', () => {
+    let service: DashboardBroadcasterService
+
+    beforeEach(() => {
+        service = new DashboardBroadcasterService()
+    })
+
+    describe('broadcast', () => {
+        it('does nothing when wss is null', () => {
+            expect(() => service.broadcast(sampleEvent)).not.toThrow()
+        })
+
+        it('sends to all OPEN clients', () => {
+            const clientA = makeClient(WsClient.OPEN)
+            const clientB = makeClient(WsClient.OPEN)
+            service.setWebSocketServer(makeWss([clientA, clientB]))
+
+            service.broadcast(sampleEvent)
+
+            expect(clientA.send).toHaveBeenCalledWith(JSON.stringify(sampleEvent))
+            expect(clientB.send).toHaveBeenCalledWith(JSON.stringify(sampleEvent))
+        })
+
+        it('skips non-OPEN clients', () => {
+            const open = makeClient(WsClient.OPEN)
+            const closed = makeClient(WsClient.CLOSED)
+            service.setWebSocketServer(makeWss([open, closed]))
+
+            service.broadcast(sampleEvent)
+
+            expect(open.send).toHaveBeenCalledOnce()
+            expect(closed.send).not.toHaveBeenCalled()
+        })
+
+        it('continues to other clients if one throws', () => {
+            const faulty = makeClient(WsClient.OPEN)
+            ;(faulty.send as ReturnType<typeof vi.fn>).mockImplementation(() => { throw new Error('fail') })
+            const good = makeClient(WsClient.OPEN)
+            service.setWebSocketServer(makeWss([faulty, good]))
+
+            expect(() => service.broadcast(sampleEvent)).not.toThrow()
+            expect(good.send).toHaveBeenCalledOnce()
+        })
+    })
+
+    describe('getClientCount', () => {
+        it('returns 0 when wss is null', () => {
+            expect(service.getClientCount()).toBe(0)
+        })
+
+        it('counts only OPEN clients', () => {
+            const open = makeClient(WsClient.OPEN)
+            const closed = makeClient(WsClient.CLOSED)
+            service.setWebSocketServer(makeWss([open, closed]))
+            expect(service.getClientCount()).toBe(1)
+        })
+
+        it('returns 0 when no clients are OPEN', () => {
+            service.setWebSocketServer(makeWss([makeClient(WsClient.CLOSED)]))
+            expect(service.getClientCount()).toBe(0)
+        })
+    })
+})

--- a/tests/src/server.test.ts
+++ b/tests/src/server.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockWss = { on: vi.fn(), clients: new Set() }
-const mockServer = { listen: vi.fn() }
+const mockServer = { listen: vi.fn(), on: vi.fn() }
 const mockApp = { use: vi.fn(), get: vi.fn() }
 
 vi.mock('ws', () => ({
@@ -32,6 +32,7 @@ describe('server module', () => {
     it('exports wss, app, and server', async () => {
         const mod = await import('../../backend/src/server.js')
         expect(mod.wss).toBeDefined()
+        expect(mod.dashboardWss).toBeDefined()
         expect(mod.app).toBeDefined()
         expect(mod.server).toBeDefined()
     })


### PR DESCRIPTION
## Summary
- Polls Twitch Get Chatters API every 60s to maintain a live viewer list with watch-time tracking
- Tracks per-viewer chat messages, bits cheered, subscriptions, and channel points redeemed via EventSub events
- Adds `GET /api/viewers` endpoint returning all viewers sorted by watch time
- `ViewersPanel` React component with a table showing username, watch time, messages, bits, subs, and points
- Real-time flash (green) + unique synthesised beep on chat message; beep pitch is deterministically hashed from userId across 20 pentatonic pitches (5 notes × 4 octaves)
- Fixes `eventsFired` stat — now only increments when a configured event actually matches, not on every Twitch event
- Fixes WebSocket multi-server routing (switched to `noServer: true` + manual upgrade handler so overlay and dashboard WS paths don't conflict)
- Fixes browser AudioContext autoplay policy with shared instance + `ctx.resume()`
- Awaits `TwitchClient.whenReady()` before starting viewer poll so `channelId` is populated
- Fixes pre-existing `TwitchClient` tests that were passing raw `EventSubMessage` shape to a method expecting parsed `EventSubNotification`

## Test plan
- [ ] `npm test` — all tests pass (excluding pre-existing `auth.test.ts` and `database.test.ts` failures)
- [ ] Start stream; verify viewer list populates within 60s
- [ ] Send a chat message; verify the sender flashes green and a beep plays
- [ ] Multiple users chatting produce distinct beep pitches
- [ ] Bits / sub / channel point redemption events update the correct viewer row
- [ ] `GET /api/viewers` returns correct JSON
- [ ] Overlay WebSocket (`/ws/overlay`) still receives events unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)