### PR TITLE
[#92] Asset caching: download external URLs on connection and serve locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,9 @@ Thumbs.db
 # Assets (streamer media files — managed locally, not in version control)
 assets/
 
+# Downloaded asset cache (runtime, rebuilt on connection)
+cache/
+
 # Database files (contain user data)
 backend/data/
 *.db

--- a/backend/config/events.ts
+++ b/backend/config/events.ts
@@ -60,7 +60,7 @@ export const EVENTS: Record<string, EventConfig> = {
         reactions: [
             { type: 'chat_reply', message: 'Thanks {{username}} for the follow!' },
             { type: 'overlay_text', text: '{{username}} is following!', transition_in: 'bounce-in', transition_out: 'bounce-out', timeout: '20s' },
-            { type: 'video', filename: 'follow-dance.mp4', transition_in: 'bounce-in', transition_out: 'bounce-out', timeout: '20s' },
+            { type: 'video', filename: 'follow-dance.mp4', transition_in: 'bounce-in', transition_out: 'bounce-out' },
             { type: 'sound', filename: 'follow.mp3' },
         ],
     },

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -139,6 +139,7 @@ app.post('/api/events', async (req: Request, res: Response) => {
         res.status(409).json({ error: 'Event already exists' });
         return;
     }
+    assetCacheService.invalidate();
     res.status(201).json({ ok: true });
 });
 
@@ -148,7 +149,26 @@ app.put('/api/events/:name', async (req: Request, res: Response) => {
         res.status(404).json({ error: 'Event not found' });
         return;
     }
+    assetCacheService.invalidate();
     res.json({ ok: true });
+});
+
+app.post('/api/asset/preview', async (req: Request, res: Response) => {
+    const { url, assetType } = req.body as { url?: string; assetType?: string };
+    if (!url || !assetType) {
+        res.status(400).json({ error: 'url and assetType are required' });
+        return;
+    }
+    if (!['image', 'sound', 'video'].includes(assetType)) {
+        res.status(400).json({ error: 'assetType must be image, sound, or video' });
+        return;
+    }
+    try {
+        const path = await assetCacheService.previewUrl(url, assetType as 'image' | 'sound' | 'video');
+        res.json({ path });
+    } catch (error) {
+        res.status(422).json({ error: error instanceof Error ? error.message : String(error) });
+    }
 });
 
 app.delete('/api/events/:name', async (req: Request, res: Response) => {

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -140,6 +140,7 @@ app.post('/api/events', async (req: Request, res: Response) => {
         return;
     }
     assetCacheService.invalidate();
+    void assetCacheService.ensureReady(eventStorage.getAll());
     res.status(201).json({ ok: true });
 });
 
@@ -150,6 +151,7 @@ app.put('/api/events/:name', async (req: Request, res: Response) => {
         return;
     }
     assetCacheService.invalidate();
+    void assetCacheService.ensureReady(eventStorage.getAll());
     res.json({ ok: true });
 });
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -12,6 +12,7 @@ import sessionStats from './src/SessionStats.js';
 import eventLog from './src/EventLog.js';
 import eventStorage from './src/EventStorage.js';
 import viewerTracker from './src/ViewerTracker.js';
+import assetCacheService from './src/services/AssetCacheService.js';
 import { wss, dashboardWss, app } from './src/server.js';
 
 Logger.info('Starting Twitch project backend...');
@@ -27,6 +28,9 @@ try {
     overlayBroadcasterService = new OverlayBroadcasterService(wss);
     dashboardBroadcasterService = new DashboardBroadcasterService(dashboardWss);
     viewerTracker.setDashboardBroadcaster(dashboardBroadcasterService);
+    assetCacheService.setProgressCallback((current, total, done) => {
+        void overlayBroadcasterService!.broadcast({ type: 'cache_progress', current, total, done });
+    });
 
     if (process.env.TWITCH_ACCESS_TOKEN && process.env.TWITCH_CLIENT_ID) {
         eventRouter = new EventRouter(null, overlayBroadcasterService);

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -182,6 +182,22 @@ app.post('/api/mod/ban/:userId', async (req: Request, res: Response) => {
     res.json({ ok: true });
 });
 
+app.post('/api/overlay-log', (req: Request, res: Response) => {
+    const { level, message } = req.body as { level?: string; message?: string };
+    if (!message) { res.status(400).json({ error: 'message required' }); return; }
+
+    const now = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const timestamp = `${pad(now.getDate())}-${pad(now.getMonth() + 1)}-${now.getFullYear()} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+    const line = `[${timestamp}] [${assetCacheService.getHash()}] [Overlay] ${message}`;
+
+    if (level === 'error') console.error(line);
+    else if (level === 'warn')  console.warn(line);
+    else                        console.log(line);
+
+    res.json({ ok: true });
+});
+
 app.get('/api/status', (_req: Request, res: Response) => {
     const twitchStatus = twitchClient?.getStatus() ?? {
         bot: { connected: false },

--- a/backend/src/base/Handler.ts
+++ b/backend/src/base/Handler.ts
@@ -1,5 +1,6 @@
 import Logger from '../utils/Logger.js';
 import type { EventConfig, ITwitchClient, IOverlayBroadcaster, OverlayEvent, OverlayReaction, TemplateData } from '../types.js';
+import assetCacheService from '../services/AssetCacheService.js';
 
 export class Handler {
     protected twitchClient: ITwitchClient | null;
@@ -33,6 +34,15 @@ export class Handler {
                     ...reaction,
                     text: this.processTemplate(reaction.text, templateData),
                 });
+            } else if (reaction.type === 'image') {
+                const url = assetCacheService.resolve(reaction.url, 'image');
+                if (url) overlayReactions.push({ ...reaction, url });
+            } else if (reaction.type === 'sound') {
+                const filename = assetCacheService.resolve(reaction.filename, 'sound');
+                if (filename) overlayReactions.push({ ...reaction, filename });
+            } else if (reaction.type === 'video') {
+                const filename = assetCacheService.resolve(reaction.filename, 'video');
+                if (filename) overlayReactions.push({ ...reaction, filename });
             } else {
                 overlayReactions.push(reaction);
             }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,8 @@ import { createServer, type Server } from 'http';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import Logger from './utils/Logger.js';
+import assetCacheService, { CACHE_ROOT } from './services/AssetCacheService.js';
+import eventStorage from './EventStorage.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -28,6 +30,8 @@ server.on('upgrade', (req, socket, head) => {
 
 wss.on('connection', (ws) => {
     Logger.info('Overlay connected');
+    assetCacheService.onConnect();
+    void assetCacheService.ensureReady(eventStorage.getAll());
 
     ws.send(JSON.stringify({ type: 'connection', message: 'Connected to backend' }));
 
@@ -37,17 +41,27 @@ wss.on('connection', (ws) => {
 
     ws.on('close', () => {
         Logger.info('Overlay disconnected');
+        assetCacheService.onDisconnect();
     });
 });
 
 dashboardWss.on('connection', (ws) => {
     Logger.info('Dashboard connected');
-    ws.on('close', () => Logger.info('Dashboard disconnected'));
+    assetCacheService.onConnect();
+    ws.on('close', () => {
+        Logger.info('Dashboard disconnected');
+        assetCacheService.onDisconnect();
+    });
 });
 
 app.use(express.json());
 app.use('/overlay', express.static(join(__dirname, '../../overlay')));
 app.use('/assets', express.static(join(__dirname, '../../assets')));
+app.use('/cache', express.static(CACHE_ROOT));
+app.use('/dashboard', (_req, _res, next) => {
+    void assetCacheService.ensureReady(eventStorage.getAll());
+    next();
+});
 app.use('/dashboard', express.static(join(__dirname, '../../dist/dashboard')));
 
 app.get('/', (_req: Request, res: Response) => {

--- a/backend/src/services/AssetCacheService.ts
+++ b/backend/src/services/AssetCacheService.ts
@@ -9,24 +9,34 @@ import type { EventConfig } from '../types.js';
 type CacheState = 'pending' | 'downloading' | 'ready' | 'error';
 
 const ASSET_TYPES = {
-    image: { dir: 'img',   extensions: ['jpg', 'jpeg', 'png', 'gif'] },
-    sound: { dir: 'audio', extensions: ['mp3', 'm4a'] },
-    video: { dir: 'video', extensions: ['mp4'] },
+    image: { dir: 'img' },
+    sound: { dir: 'audio' },
+    video: { dir: 'video' },
 } as const;
 
 type AssetType = keyof typeof ASSET_TYPES;
+
+export const MIME_TO_EXT: Record<string, string> = {
+    'image/jpeg':    'jpg',
+    'image/png':     'png',
+    'image/gif':     'gif',
+    'audio/mpeg':    'mp3',
+    'audio/mp4':     'm4a',
+    'audio/x-m4a':  'm4a',
+    'video/mp4':     'mp4',
+};
+
+const ALLOWED_MIMES: Record<AssetType, string[]> = {
+    image: ['image/jpeg', 'image/png', 'image/gif'],
+    sound: ['audio/mpeg', 'audio/mp4', 'audio/x-m4a'],
+    video: ['video/mp4'],
+};
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const CACHE_ROOT = join(__dirname, '../../../../cache');
 
 export function isExternalUrl(value: string): boolean {
     return value.startsWith('http://') || value.startsWith('https://');
-}
-
-export function extractExtension(value: string): string | null {
-    const clean = value.split('?')[0].split('#')[0];
-    const dot = clean.lastIndexOf('.');
-    return dot >= 0 ? clean.slice(dot + 1).toLowerCase() : null;
 }
 
 export function extractAssetUrls(configs: EventConfig[]): { url: string; assetType: AssetType }[] {
@@ -63,6 +73,7 @@ export class AssetCacheService {
     private connectionCount = 0;
     private cleanupTimer: ReturnType<typeof setTimeout> | null = null;
     private progressCallback: ProgressCallback | null = null;
+    private urlExtensionMap = new Map<string, string>();
 
     setProgressCallback(cb: ProgressCallback): void {
         this.progressCallback = cb;
@@ -96,7 +107,7 @@ export class AssetCacheService {
         } catch (error) {
             this.state = 'error';
             this.broadcastProgress(0, 0, true);
-            Logger.error('AssetCacheService: Download failed, falling back to original URLs', error);
+            Logger.error('AssetCacheService: Download failed', error);
         }
     }
 
@@ -120,7 +131,7 @@ export class AssetCacheService {
     resolve(value: string, assetType: AssetType): string {
         if (!isExternalUrl(value) || this.state !== 'ready') return '';
 
-        const ext = extractExtension(value);
+        const ext = this.urlExtensionMap.get(value);
         if (!ext) return '';
 
         const { dir } = ASSET_TYPES[assetType];
@@ -142,24 +153,30 @@ export class AssetCacheService {
         let completed = 0;
 
         await Promise.all(assets.map(async ({ url, assetType }) => {
-            const ext = extractExtension(url);
-            if (!ext) { Logger.warn(`AssetCacheService: No extension for ${url}, skipping`); return; }
-
-            const { dir, extensions } = ASSET_TYPES[assetType];
-            if (!(extensions as readonly string[]).includes(ext)) {
-                Logger.warn(`AssetCacheService: Unsupported extension .${ext} for ${assetType}, skipping`);
-                return;
-            }
-
-            const filename = `${createHash('sha256').update(url).digest('hex').slice(0, 12)}.${ext}`;
-            const dest = join(this.cacheDir, dir, filename);
-
             try {
                 const response = await fetch(url);
                 if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+                const mimeType = response.headers.get('content-type')?.split(';')[0].trim() ?? '';
+                const ext = MIME_TO_EXT[mimeType];
+
+                if (!ext) {
+                    Logger.warn(`AssetCacheService: Unsupported content-type "${mimeType}" for ${url}, skipping`);
+                    return;
+                }
+                if (!ALLOWED_MIMES[assetType].includes(mimeType)) {
+                    Logger.warn(`AssetCacheService: "${mimeType}" not allowed for ${assetType} reaction, skipping`);
+                    return;
+                }
+
+                const { dir } = ASSET_TYPES[assetType];
+                const filename = `${createHash('sha256').update(url).digest('hex').slice(0, 12)}.${ext}`;
+                const dest = join(this.cacheDir, dir, filename);
+
                 const buffer = await response.arrayBuffer();
                 await writeFile(dest, Buffer.from(buffer));
-                Logger.info(`AssetCacheService: Cached ${url}`);
+                this.urlExtensionMap.set(url, ext);
+                Logger.info(`AssetCacheService: Cached ${url} as ${ext}`);
             } catch (error) {
                 Logger.error(`AssetCacheService: Failed to download ${url}`, error);
             }
@@ -178,6 +195,7 @@ export class AssetCacheService {
             }
             this.state = 'pending';
             this.cleanupTimer = null;
+            this.urlExtensionMap.clear();
             Logger.info(`AssetCacheService: Cache cleaned up`);
         } catch (error) {
             Logger.error('AssetCacheService: Cleanup failed', error);

--- a/backend/src/services/AssetCacheService.ts
+++ b/backend/src/services/AssetCacheService.ts
@@ -41,6 +41,31 @@ function normalizeGoogleUrl(url: string): string {
     return url;
 }
 
+async function fetchAsset(url: string): Promise<Response> {
+    const response = await fetch(url);
+    if (!response.ok) return response;
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.startsWith('text/html') || !/google\.com/.test(url)) return response;
+
+    // Google returned a confirmation page — parse the form and resubmit
+    const html = await response.text();
+    const actionMatch = html.match(/action="([^"]+)"/);
+    if (!actionMatch) return response;
+
+    const action = actionMatch[1].replace(/&amp;/g, '&');
+    const base = action.startsWith('http') ? action : `https://drive.google.com${action}`;
+    const params = new URLSearchParams();
+    for (const [, name, value] of html.matchAll(/name="([^"]+)"\s+value="([^"]*)"/g)) {
+        params.set(name, value);
+    }
+
+    if (!params.has('id')) return response;
+
+    Logger.info(`AssetCacheService: Following Google Drive confirmation for ${url}`);
+    return fetch(`${base}?${params}`);
+}
+
 export function isExternalUrl(value: string): boolean {
     return value.startsWith('http://') || value.startsWith('https://');
 }
@@ -154,7 +179,7 @@ export class AssetCacheService {
 
         await mkdir(join(this.cacheDir, ASSET_TYPES[assetType].dir), { recursive: true });
 
-        const response = await fetch(fetchUrl);
+        const response = await fetchAsset(fetchUrl);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
         const mimeType = response.headers.get('content-type')?.split(';')[0].trim() ?? '';
@@ -200,7 +225,7 @@ export class AssetCacheService {
 
         await Promise.all(assets.map(async ({ url, assetType }) => {
             try {
-                const response = await fetch(normalizeGoogleUrl(url));
+                const response = await fetchAsset(normalizeGoogleUrl(url));
                 if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
                 const mimeType = response.headers.get('content-type')?.split(';')[0].trim() ?? '';

--- a/backend/src/services/AssetCacheService.ts
+++ b/backend/src/services/AssetCacheService.ts
@@ -35,6 +35,12 @@ const ALLOWED_MIMES: Record<AssetType, string[]> = {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const CACHE_ROOT = join(__dirname, '../../../../cache');
 
+function normalizeGoogleUrl(url: string): string {
+    const ucMatch = url.match(/drive\.google\.com\/(?:open|uc)\?.*?[?&]id=([^&]+)/);
+    if (ucMatch) return `https://drive.usercontent.google.com/download?id=${ucMatch[1]}&export=download&authuser=0`;
+    return url;
+}
+
 export function isExternalUrl(value: string): boolean {
     return value.startsWith('http://') || value.startsWith('https://');
 }
@@ -137,6 +143,8 @@ export class AssetCacheService {
     async previewUrl(url: string, assetType: AssetType): Promise<string> {
         if (!isExternalUrl(url)) throw new Error('Must be an external URL');
 
+        const fetchUrl = normalizeGoogleUrl(url);
+
         const existingExt = this.urlExtensionMap.get(url);
         if (existingExt) {
             const { dir } = ASSET_TYPES[assetType];
@@ -146,7 +154,7 @@ export class AssetCacheService {
 
         await mkdir(join(this.cacheDir, ASSET_TYPES[assetType].dir), { recursive: true });
 
-        const response = await fetch(url);
+        const response = await fetch(fetchUrl);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
         const mimeType = response.headers.get('content-type')?.split(';')[0].trim() ?? '';
@@ -192,7 +200,7 @@ export class AssetCacheService {
 
         await Promise.all(assets.map(async ({ url, assetType }) => {
             try {
-                const response = await fetch(url);
+                const response = await fetch(normalizeGoogleUrl(url));
                 if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
                 const mimeType = response.headers.get('content-type')?.split(';')[0].trim() ?? '';

--- a/backend/src/services/AssetCacheService.ts
+++ b/backend/src/services/AssetCacheService.ts
@@ -1,0 +1,167 @@
+import { createHash } from 'crypto';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import Logger from '../utils/Logger.js';
+import type { EventConfig } from '../types.js';
+
+type CacheState = 'pending' | 'downloading' | 'ready' | 'error';
+
+const ASSET_TYPES = {
+    image: { dir: 'img',   extensions: ['jpg', 'jpeg', 'png', 'gif'] },
+    sound: { dir: 'audio', extensions: ['mp3', 'm4a'] },
+    video: { dir: 'video', extensions: ['mp4'] },
+} as const;
+
+type AssetType = keyof typeof ASSET_TYPES;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const CACHE_ROOT = join(__dirname, '../../../../cache');
+
+export function isExternalUrl(value: string): boolean {
+    return value.startsWith('http://') || value.startsWith('https://');
+}
+
+export function extractExtension(value: string): string | null {
+    const clean = value.split('?')[0].split('#')[0];
+    const dot = clean.lastIndexOf('.');
+    return dot >= 0 ? clean.slice(dot + 1).toLowerCase() : null;
+}
+
+export function extractAssetUrls(configs: EventConfig[]): { url: string; assetType: AssetType }[] {
+    const seen = new Set<string>();
+    const results: { url: string; assetType: AssetType }[] = [];
+
+    for (const config of configs) {
+        for (const reaction of config.reactions) {
+            let url: string | undefined;
+            let assetType: AssetType | undefined;
+
+            if (reaction.type === 'image' && isExternalUrl(reaction.url)) {
+                url = reaction.url; assetType = 'image';
+            } else if (reaction.type === 'sound' && isExternalUrl(reaction.filename)) {
+                url = reaction.filename; assetType = 'sound';
+            } else if (reaction.type === 'video' && isExternalUrl(reaction.filename)) {
+                url = reaction.filename; assetType = 'video';
+            }
+
+            if (url && assetType && !seen.has(url)) {
+                seen.add(url);
+                results.push({ url, assetType });
+            }
+        }
+    }
+
+    return results;
+}
+
+export class AssetCacheService {
+    private state: CacheState = 'pending';
+    private connectionCount = 0;
+    private cleanupTimer: ReturnType<typeof setTimeout> | null = null;
+
+    private get channelHash(): string {
+        return createHash('sha256')
+            .update(process.env.TWITCH_CHANNEL_NAME ?? 'default')
+            .digest('hex')
+            .slice(0, 12);
+    }
+
+    private get cacheDir(): string {
+        return join(CACHE_ROOT, this.channelHash);
+    }
+
+    getHash(): string { return this.channelHash; }
+
+    async ensureReady(configs: EventConfig[]): Promise<void> {
+        if (this.state === 'ready' || this.state === 'downloading') return;
+
+        this.state = 'downloading';
+        try {
+            await this.download(configs);
+            this.state = 'ready';
+            Logger.info(`AssetCacheService: Cache ready at ${this.cacheDir}`);
+        } catch (error) {
+            this.state = 'error';
+            Logger.error('AssetCacheService: Download failed, falling back to original URLs', error);
+        }
+    }
+
+    onConnect(): void {
+        this.connectionCount++;
+        if (this.cleanupTimer !== null) {
+            clearTimeout(this.cleanupTimer);
+            this.cleanupTimer = null;
+            Logger.info('AssetCacheService: Cleanup timer cancelled (reconnection)');
+        }
+    }
+
+    onDisconnect(): void {
+        this.connectionCount = Math.max(0, this.connectionCount - 1);
+        if (this.connectionCount === 0) {
+            Logger.info('AssetCacheService: All connections closed — cleanup in 1 hour');
+            this.cleanupTimer = setTimeout(() => void this.cleanup(), 60 * 60 * 1000);
+        }
+    }
+
+    resolve(value: string, assetType: AssetType): string {
+        if (!isExternalUrl(value) || this.state !== 'ready') return '';
+
+        const ext = extractExtension(value);
+        if (!ext) return '';
+
+        const { dir } = ASSET_TYPES[assetType];
+        const filename = `${createHash('sha256').update(value).digest('hex').slice(0, 12)}.${ext}`;
+        return `/cache/${this.channelHash}/${dir}/${filename}`;
+    }
+
+    private async download(configs: EventConfig[]): Promise<void> {
+        for (const { dir } of Object.values(ASSET_TYPES)) {
+            await mkdir(join(this.cacheDir, dir), { recursive: true });
+        }
+
+        const assets = extractAssetUrls(configs);
+        Logger.info(`AssetCacheService: Downloading ${assets.length} asset(s)`);
+
+        await Promise.all(assets.map(async ({ url, assetType }) => {
+            const ext = extractExtension(url);
+            if (!ext) { Logger.warn(`AssetCacheService: No extension for ${url}, skipping`); return; }
+
+            const { dir, extensions } = ASSET_TYPES[assetType];
+            if (!(extensions as readonly string[]).includes(ext)) {
+                Logger.warn(`AssetCacheService: Unsupported extension .${ext} for ${assetType}, skipping`);
+                return;
+            }
+
+            const filename = `${createHash('sha256').update(url).digest('hex').slice(0, 12)}.${ext}`;
+            const dest = join(this.cacheDir, dir, filename);
+
+            try {
+                const response = await fetch(url);
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const buffer = await response.arrayBuffer();
+                await writeFile(dest, Buffer.from(buffer));
+                Logger.info(`AssetCacheService: Cached ${url}`);
+            } catch (error) {
+                Logger.error(`AssetCacheService: Failed to download ${url}`, error);
+            }
+        }));
+    }
+
+    private async cleanup(): Promise<void> {
+        try {
+            if (existsSync(this.cacheDir)) {
+                await rm(this.cacheDir, { recursive: true });
+            }
+            this.state = 'pending';
+            this.cleanupTimer = null;
+            Logger.info(`AssetCacheService: Cache cleaned up`);
+        } catch (error) {
+            Logger.error('AssetCacheService: Cleanup failed', error);
+        }
+    }
+}
+
+const assetCacheService = new AssetCacheService();
+export default assetCacheService;

--- a/backend/src/services/AssetCacheService.ts
+++ b/backend/src/services/AssetCacheService.ts
@@ -43,6 +43,11 @@ function normalizeGoogleUrl(url: string): string {
 
 async function fetchAsset(url: string): Promise<Response> {
     const response = await fetch(url);
+
+    if (response.url.includes('accounts.google.com')) {
+        throw new Error('This Google Drive file requires sign-in. Set sharing to "Anyone on the internet with this link".');
+    }
+
     if (!response.ok) return response;
 
     const contentType = response.headers.get('content-type') ?? '';

--- a/backend/src/services/AssetCacheService.ts
+++ b/backend/src/services/AssetCacheService.ts
@@ -32,6 +32,48 @@ const ALLOWED_MIMES: Record<AssetType, string[]> = {
     video: ['video/mp4'],
 };
 
+// Hosts like Dropbox serve files with a generic/opaque Content-Type; for these
+// we ignore the header and detect the real type from the bytes or URL instead.
+const GENERIC_MIMES = new Set([
+    '', 'application/binary', 'application/octet-stream',
+    'binary/octet-stream', 'application/download',
+]);
+
+const EXT_TO_MIME: Record<string, string> = {
+    jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', gif: 'image/gif',
+    mp3: 'audio/mpeg', m4a: 'audio/x-m4a', mp4: 'video/mp4',
+};
+
+function sniffMime(buffer: Buffer): string | undefined {
+    const b = buffer;
+    if (b.length >= 4 && b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return 'image/png';
+    if (b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return 'image/jpeg';
+    if (b.length >= 6 && (b.toString('ascii', 0, 6) === 'GIF87a' || b.toString('ascii', 0, 6) === 'GIF89a')) return 'image/gif';
+    if (b.length >= 3 && b.toString('ascii', 0, 3) === 'ID3') return 'audio/mpeg';
+    if (b.length >= 2 && b[0] === 0xff && (b[1] & 0xe0) === 0xe0) return 'audio/mpeg';
+    if (b.length >= 12 && b.toString('ascii', 4, 8) === 'ftyp') {
+        return b.toString('ascii', 8, 11) === 'M4A' ? 'audio/mp4' : 'video/mp4';
+    }
+    return undefined;
+}
+
+function mimeFromUrlExt(url: string): string | undefined {
+    const ext = url.split(/[?#]/)[0].split('.').pop()?.toLowerCase();
+    return ext ? EXT_TO_MIME[ext] : undefined;
+}
+
+/**
+ * Resolve the canonical MIME type for a downloaded asset. A specific, known
+ * Content-Type is trusted; a specific-but-unsupported one is rejected; a
+ * generic one (e.g. Dropbox's application/binary) is resolved by sniffing the
+ * magic bytes, then falling back to the URL's file extension.
+ */
+export function resolveAssetMime(headerMime: string, buffer: Buffer, url: string): string | undefined {
+    if (MIME_TO_EXT[headerMime]) return headerMime;
+    if (!GENERIC_MIMES.has(headerMime)) return undefined;
+    return sniffMime(buffer) ?? mimeFromUrlExt(url);
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const CACHE_ROOT = join(__dirname, '../../../../cache');
 
@@ -187,17 +229,19 @@ export class AssetCacheService {
         const response = await fetchAsset(fetchUrl);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
-        const mimeType = response.headers.get('content-type')?.split(';')[0].trim() ?? '';
-        const ext = MIME_TO_EXT[mimeType];
-        if (!ext) throw new Error(`Unsupported content type: ${mimeType || '(none)'}`);
+        const headerMime = response.headers.get('content-type')?.split(';')[0].trim() ?? '';
+        const buffer = Buffer.from(await response.arrayBuffer());
+        const mimeType = resolveAssetMime(headerMime, buffer, url);
+
+        if (!mimeType) throw new Error(`Unsupported content type: ${headerMime || '(none)'}`);
         if (!ALLOWED_MIMES[assetType].includes(mimeType)) throw new Error(`"${mimeType}" is not valid for ${assetType}`);
 
+        const ext = MIME_TO_EXT[mimeType];
         const { dir } = ASSET_TYPES[assetType];
         const filename = `${createHash('sha256').update(url).digest('hex').slice(0, 12)}.${ext}`;
         const dest = join(this.cacheDir, dir, filename);
 
-        const buffer = await response.arrayBuffer();
-        await writeFile(dest, Buffer.from(buffer));
+        await writeFile(dest, buffer);
         this.urlExtensionMap.set(url, ext);
 
         Logger.info(`AssetCacheService: Previewed and cached ${url}`);
@@ -233,11 +277,12 @@ export class AssetCacheService {
                 const response = await fetchAsset(normalizeGoogleUrl(url));
                 if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
-                const mimeType = response.headers.get('content-type')?.split(';')[0].trim() ?? '';
-                const ext = MIME_TO_EXT[mimeType];
+                const headerMime = response.headers.get('content-type')?.split(';')[0].trim() ?? '';
+                const buffer = Buffer.from(await response.arrayBuffer());
+                const mimeType = resolveAssetMime(headerMime, buffer, url);
 
-                if (!ext) {
-                    Logger.warn(`AssetCacheService: Unsupported content-type "${mimeType}" for ${url}, skipping`);
+                if (!mimeType) {
+                    Logger.warn(`AssetCacheService: Unsupported content-type "${headerMime}" for ${url}, skipping`);
                     return;
                 }
                 if (!ALLOWED_MIMES[assetType].includes(mimeType)) {
@@ -245,12 +290,12 @@ export class AssetCacheService {
                     return;
                 }
 
+                const ext = MIME_TO_EXT[mimeType];
                 const { dir } = ASSET_TYPES[assetType];
                 const filename = `${createHash('sha256').update(url).digest('hex').slice(0, 12)}.${ext}`;
                 const dest = join(this.cacheDir, dir, filename);
 
-                const buffer = await response.arrayBuffer();
-                await writeFile(dest, Buffer.from(buffer));
+                await writeFile(dest, buffer);
                 this.urlExtensionMap.set(url, ext);
                 Logger.info(`AssetCacheService: Cached ${url} as ${ext}`);
             } catch (error) {

--- a/backend/src/services/AssetCacheService.ts
+++ b/backend/src/services/AssetCacheService.ts
@@ -56,10 +56,21 @@ export function extractAssetUrls(configs: EventConfig[]): { url: string; assetTy
     return results;
 }
 
+type ProgressCallback = (current: number, total: number, done: boolean) => void;
+
 export class AssetCacheService {
     private state: CacheState = 'pending';
     private connectionCount = 0;
     private cleanupTimer: ReturnType<typeof setTimeout> | null = null;
+    private progressCallback: ProgressCallback | null = null;
+
+    setProgressCallback(cb: ProgressCallback): void {
+        this.progressCallback = cb;
+    }
+
+    private broadcastProgress(current: number, total: number, done: boolean): void {
+        this.progressCallback?.(current, total, done);
+    }
 
     private get channelHash(): string {
         return createHash('sha256')
@@ -84,6 +95,7 @@ export class AssetCacheService {
             Logger.info(`AssetCacheService: Cache ready at ${this.cacheDir}`);
         } catch (error) {
             this.state = 'error';
+            this.broadcastProgress(0, 0, true);
             Logger.error('AssetCacheService: Download failed, falling back to original URLs', error);
         }
     }
@@ -124,6 +136,11 @@ export class AssetCacheService {
         const assets = extractAssetUrls(configs);
         Logger.info(`AssetCacheService: Downloading ${assets.length} asset(s)`);
 
+        if (assets.length === 0) return;
+
+        this.broadcastProgress(0, assets.length, false);
+        let completed = 0;
+
         await Promise.all(assets.map(async ({ url, assetType }) => {
             const ext = extractExtension(url);
             if (!ext) { Logger.warn(`AssetCacheService: No extension for ${url}, skipping`); return; }
@@ -146,7 +163,12 @@ export class AssetCacheService {
             } catch (error) {
                 Logger.error(`AssetCacheService: Failed to download ${url}`, error);
             }
+
+            completed++;
+            this.broadcastProgress(completed, assets.length, false);
         }));
+
+        this.broadcastProgress(assets.length, assets.length, true);
     }
 
     private async cleanup(): Promise<void> {

--- a/backend/src/services/AssetCacheService.ts
+++ b/backend/src/services/AssetCacheService.ts
@@ -128,6 +128,44 @@ export class AssetCacheService {
         }
     }
 
+    invalidate(): void {
+        this.state = 'pending';
+        this.urlExtensionMap.clear();
+        Logger.info('AssetCacheService: Cache invalidated');
+    }
+
+    async previewUrl(url: string, assetType: AssetType): Promise<string> {
+        if (!isExternalUrl(url)) throw new Error('Must be an external URL');
+
+        const existingExt = this.urlExtensionMap.get(url);
+        if (existingExt) {
+            const { dir } = ASSET_TYPES[assetType];
+            const filename = `${createHash('sha256').update(url).digest('hex').slice(0, 12)}.${existingExt}`;
+            return `/cache/${this.channelHash}/${dir}/${filename}`;
+        }
+
+        await mkdir(join(this.cacheDir, ASSET_TYPES[assetType].dir), { recursive: true });
+
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+        const mimeType = response.headers.get('content-type')?.split(';')[0].trim() ?? '';
+        const ext = MIME_TO_EXT[mimeType];
+        if (!ext) throw new Error(`Unsupported content type: ${mimeType || '(none)'}`);
+        if (!ALLOWED_MIMES[assetType].includes(mimeType)) throw new Error(`"${mimeType}" is not valid for ${assetType}`);
+
+        const { dir } = ASSET_TYPES[assetType];
+        const filename = `${createHash('sha256').update(url).digest('hex').slice(0, 12)}.${ext}`;
+        const dest = join(this.cacheDir, dir, filename);
+
+        const buffer = await response.arrayBuffer();
+        await writeFile(dest, Buffer.from(buffer));
+        this.urlExtensionMap.set(url, ext);
+
+        Logger.info(`AssetCacheService: Previewed and cached ${url}`);
+        return `/cache/${this.channelHash}/${dir}/${filename}`;
+    }
+
     resolve(value: string, assetType: AssetType): string {
         if (!isExternalUrl(value) || this.state !== 'ready') return '';
 

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -26,6 +26,8 @@ export interface SoundReaction {
     type: 'sound'
     filename: string
     volume?: number
+    startTime?: number
+    endTime?: number
 }
 
 export interface VideoReaction {
@@ -36,7 +38,8 @@ export interface VideoReaction {
     offsetZ?: number
     transition_in?: string
     transition_out?: string
-    timeout?: string
+    startTime?: number
+    endTime?: number
 }
 
 export type OverlayReaction = OverlayTextReaction | ImageReaction | SoundReaction | VideoReaction

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -56,11 +56,20 @@ export interface TwitchRawEvent {
     event: Record<string, unknown>
 }
 
-export interface OverlayEvent {
+export interface OverlayReactionEvent {
     type: 'event'
     event_name: string
     reactions: OverlayReaction[]
 }
+
+export interface CacheProgressEvent {
+    type: 'cache_progress'
+    current: number
+    total: number
+    done: boolean
+}
+
+export type OverlayEvent = OverlayReactionEvent | CacheProgressEvent
 
 export interface DashboardChatEvent {
     type: 'chat'

--- a/frontend/src/components/EventModal.tsx
+++ b/frontend/src/components/EventModal.tsx
@@ -113,7 +113,7 @@ export default function EventModal({ event, onSave, onClose }: Props) {
       style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.75)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}
       onClick={e => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="card" style={{ width: 820, maxWidth: '95vw', height: '92vh', display: 'flex', flexDirection: 'column', padding: 0, overflow: 'hidden' }}>
+      <div className="card" style={{ width: '78vw', height: '92vh', display: 'flex', flexDirection: 'column', padding: 0, overflow: 'hidden' }}>
 
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>

--- a/frontend/src/components/EventModal.tsx
+++ b/frontend/src/components/EventModal.tsx
@@ -113,7 +113,7 @@ export default function EventModal({ event, onSave, onClose }: Props) {
       style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.75)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}
       onClick={e => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="card" style={{ width: 560, height: '92vh', display: 'flex', flexDirection: 'column', padding: 0, overflow: 'hidden' }}>
+      <div className="card" style={{ width: 820, maxWidth: '95vw', height: '92vh', display: 'flex', flexDirection: 'column', padding: 0, overflow: 'hidden' }}>
 
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
@@ -123,24 +123,25 @@ export default function EventModal({ event, onSave, onClose }: Props) {
 
         {/* Fixed fields — event name, type, trigger */}
         <div style={{ padding: '20px 20px 0', flexShrink: 0 }}>
-          <div className="field">
-            <label>EVENT NAME</label>
-            <input
-              value={form.event_name}
-              onChange={e => setField('event_name', e.target.value)}
-              placeholder="my_event"
-              disabled={!isCreate}
-              style={!isCreate ? { opacity: 0.5 } : {}}
-            />
-          </div>
-
-          <div className="field">
-            <label>EVENT TYPE</label>
-            <select value={form.event_type} onChange={e => setField('event_type', e.target.value)}>
-              {EVENT_TYPES.map(t => (
-                <option key={t} value={t}>{t.replace(/_/g, ' ')}</option>
-              ))}
-            </select>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}>
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label>EVENT NAME</label>
+              <input
+                value={form.event_name}
+                onChange={e => setField('event_name', e.target.value)}
+                placeholder="my_event"
+                disabled={!isCreate}
+                style={!isCreate ? { opacity: 0.5 } : {}}
+              />
+            </div>
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label>EVENT TYPE</label>
+              <select value={form.event_type} onChange={e => setField('event_type', e.target.value)}>
+                {EVENT_TYPES.map(t => (
+                  <option key={t} value={t}>{t.replace(/_/g, ' ')}</option>
+                ))}
+              </select>
+            </div>
           </div>
 
           {TRIGGER_REQUIRED.has(form.event_type) && (

--- a/frontend/src/components/ReactionCard.tsx
+++ b/frontend/src/components/ReactionCard.tsx
@@ -15,12 +15,6 @@ const TRANSITION_OUT = ['', 'fade-out', 'bounce-out', 'scale-out', 'slide-right-
 
 const TEMPLATE_HINT = '{{username}}, {{display_name}}, {{count}}';
 
-const ALLOWED_EXTENSIONS = {
-  image: ['jpg', 'jpeg', 'png', 'gif'],
-  sound: ['mp3', 'm4a'],
-  video: ['mp4'],
-} as const;
-
 export function defaultReaction(type: Reaction['type']): Reaction {
   switch (type) {
     case 'chat_reply':   return { type: 'chat_reply', message: '' };
@@ -31,20 +25,24 @@ export function defaultReaction(type: Reaction['type']): Reaction {
   }
 }
 
-function getExt(value: string): string | null {
-  const clean = value.split('?')[0].split('#')[0];
-  const dot = clean.lastIndexOf('.');
-  return dot >= 0 ? clean.slice(dot + 1).toLowerCase() : null;
-}
-
-function validateAsset(value: string, type: keyof typeof ALLOWED_EXTENSIONS): string | null {
+function validateAsset(value: string): string | null {
   if (!value) return null;
   if (!value.startsWith('http://') && !value.startsWith('https://')) return 'Must be a URL starting with http:// or https://';
-  const ext = getExt(value);
-  if (!ext) return 'Cannot determine file type from URL';
-  return (ALLOWED_EXTENSIONS[type] as readonly string[]).includes(ext)
-    ? null
-    : `Allowed types: ${ALLOWED_EXTENSIONS[type].join(', ')}`;
+  return null;
+}
+
+function convertGoogleUrl(value: string): string {
+  const driveMatch = value.match(/drive\.google\.com\/file\/d\/([^/?#]+)/);
+  if (driveMatch) return `https://drive.google.com/uc?export=download&id=${driveMatch[1]}`;
+
+  const driveOpenMatch = value.match(/drive\.google\.com\/(?:open|uc)\?.*?[?&]id=([^&]+)/);
+  if (driveOpenMatch) return `https://drive.google.com/uc?export=download&id=${driveOpenMatch[1]}`;
+
+  return value;
+}
+
+function isGoogleUrl(value: string): boolean {
+  return /drive\.google\.com|photos\.google\.com/.test(value);
 }
 
 interface Props {
@@ -104,10 +102,10 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
 
       {reaction.type === 'image' && <>
         <div className="field">
-          <label>URL OR FILENAME</label>
+          <label>URL</label>
           <input
             value={reaction.url}
-            onChange={e => onChange({ ...reaction, url: e.target.value })}
+            onChange={e => onChange({ ...reaction, url: convertGoogleUrl(e.target.value) })}
             placeholder="https://example.com/image.png"
           />
           <AssetValidation value={reaction.url} assetType="image" />
@@ -119,10 +117,10 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
 
       {reaction.type === 'sound' && <>
         <div className="field">
-          <label>URL OR FILENAME</label>
+          <label>URL</label>
           <input
             value={reaction.filename}
-            onChange={e => onChange({ ...reaction, filename: e.target.value })}
+            onChange={e => onChange({ ...reaction, filename: convertGoogleUrl(e.target.value) })}
             placeholder="https://example.com/sound.mp3"
           />
           <AssetValidation value={reaction.filename} assetType="sound" />
@@ -140,10 +138,10 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
 
       {reaction.type === 'video' && <>
         <div className="field">
-          <label>URL OR FILENAME</label>
+          <label>URL</label>
           <input
             value={reaction.filename}
-            onChange={e => onChange({ ...reaction, filename: e.target.value })}
+            onChange={e => onChange({ ...reaction, filename: convertGoogleUrl(e.target.value) })}
             placeholder="https://example.com/clip.mp4"
           />
           <AssetValidation value={reaction.filename} assetType="video" />
@@ -156,39 +154,34 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
   );
 }
 
-function AssetValidation({ value, assetType }: { value: string; assetType: keyof typeof ALLOWED_EXTENSIONS }) {
+function AssetValidation({ value, assetType }: { value: string; assetType: 'image' | 'sound' | 'video' }) {
   if (!value) return null;
-  const error = validateAsset(value, assetType);
+  const error = validateAsset(value);
   if (error) return <div className="field-hint" style={{ color: 'var(--red)' }}>{error}</div>;
 
-  if (assetType === 'image') {
-    return (
-      <img
-        src={value}
-        alt="preview"
-        style={{ maxHeight: 80, maxWidth: '100%', borderRadius: 4, marginTop: 6, objectFit: 'contain', background: 'var(--bg)', display: 'block' }}
-        onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
-        onLoad={e => { (e.target as HTMLImageElement).style.display = 'block'; }}
-      />
-    );
-  }
-
-  if (assetType === 'sound') {
-    return <audio key={value} src={value} controls style={{ width: '100%', marginTop: 6 }} />;
-  }
-
-  if (assetType === 'video') {
-    return (
-      <video
-        key={value}
-        src={value}
-        controls
-        style={{ maxWidth: '100%', maxHeight: 120, marginTop: 6, borderRadius: 4, display: 'block' }}
-      />
-    );
-  }
-
-  return null;
+  return (
+    <>
+      {isGoogleUrl(value) && (
+        <div className="field-hint" style={{ color: '#a970ff' }}>
+          Your Google URL will be converted to a downloadable URL
+        </div>
+      )}
+      {assetType === 'image' && (
+        <img
+          key={value}
+          src={value}
+          alt="preview"
+          style={{ maxHeight: 80, maxWidth: '100%', borderRadius: 4, marginTop: 6, objectFit: 'contain', background: 'var(--bg)', display: 'block' }}
+          onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+          onLoad={e => { (e.target as HTMLImageElement).style.display = 'block'; }}
+        />
+      )}
+      {assetType === 'sound' && <audio key={value} src={value} controls style={{ width: '100%', marginTop: 6 }} />}
+      {assetType === 'video' && (
+        <video key={value} src={value} controls style={{ maxWidth: '100%', maxHeight: 120, marginTop: 6, borderRadius: 4, display: 'block' }} />
+      )}
+    </>
+  );
 }
 
 type WithTransitions = { transition_in?: string; transition_out?: string };

--- a/frontend/src/components/ReactionCard.tsx
+++ b/frontend/src/components/ReactionCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { Reaction } from '../../../backend/src/types.js';
 
 const ALL_REACTION_TYPES: Reaction['type'][] = ['chat_reply', 'overlay_text', 'image', 'sound', 'video'];
@@ -108,8 +109,9 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
             onChange={e => onChange({ ...reaction, url: convertGoogleUrl(e.target.value) })}
             placeholder="https://example.com/image.png"
           />
-          <AssetValidation value={reaction.url} assetType="image" />
+          <AssetValidation value={reaction.url} />
         </div>
+        <PreviewBox key={reaction.url} url={reaction.url} assetType="image" />
         <OffsetFields reaction={reaction} onChange={onChange} />
         <TransitionFields reaction={reaction} onChange={onChange} />
         <TimeoutField reaction={reaction} onChange={onChange} />
@@ -123,8 +125,9 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
             onChange={e => onChange({ ...reaction, filename: convertGoogleUrl(e.target.value) })}
             placeholder="https://example.com/sound.mp3"
           />
-          <AssetValidation value={reaction.filename} assetType="sound" />
+          <AssetValidation value={reaction.filename} />
         </div>
+        <PreviewBox key={reaction.filename} url={reaction.filename} assetType="sound" />
         <div className="field" style={{ marginBottom: 0 }}>
           <label>VOLUME (0–1)</label>
           <input
@@ -144,8 +147,9 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
             onChange={e => onChange({ ...reaction, filename: convertGoogleUrl(e.target.value) })}
             placeholder="https://example.com/clip.mp4"
           />
-          <AssetValidation value={reaction.filename} assetType="video" />
+          <AssetValidation value={reaction.filename} />
         </div>
+        <PreviewBox key={reaction.filename} url={reaction.filename} assetType="video" />
         <OffsetFields reaction={reaction} onChange={onChange} />
         <TransitionFields reaction={reaction} onChange={onChange} />
         <TimeoutField reaction={reaction} onChange={onChange} />
@@ -154,33 +158,74 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
   );
 }
 
-function AssetValidation({ value, assetType }: { value: string; assetType: 'image' | 'sound' | 'video' }) {
+function AssetValidation({ value }: { value: string }) {
   if (!value) return null;
   const error = validateAsset(value);
   if (error) return <div className="field-hint" style={{ color: 'var(--red)' }}>{error}</div>;
+  if (isGoogleUrl(value)) {
+    return (
+      <div className="field-hint" style={{ color: '#a970ff' }}>
+        Your Google URL will be converted to a downloadable URL
+      </div>
+    );
+  }
+  return null;
+}
+
+type PreviewState = 'idle' | 'loading' | 'done' | 'error';
+
+function PreviewBox({ url, assetType }: { url: string; assetType: 'image' | 'sound' | 'video' }) {
+  const [state, setState] = useState<PreviewState>('idle');
+  const [cachedPath, setCachedPath] = useState('');
+  const [error, setError] = useState('');
+
+  async function handlePreview() {
+    setState('loading');
+    setError('');
+    try {
+      const res = await fetch('/api/asset/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url, assetType }),
+      });
+      const data = await res.json() as { path?: string; error?: string };
+      if (!res.ok) {
+        setError(data.error ?? 'Preview failed');
+        setState('error');
+      } else {
+        setCachedPath(data.path ?? '');
+        setState('done');
+      }
+    } catch {
+      setError('Network error');
+      setState('error');
+    }
+  }
+
+  const validUrl = url && !validateAsset(url);
 
   return (
-    <>
-      {isGoogleUrl(value) && (
-        <div className="field-hint" style={{ color: '#a970ff' }}>
-          Your Google URL will be converted to a downloadable URL
-        </div>
+    <div style={{ border: '1px solid var(--border)', borderRadius: 4, padding: 8, marginBottom: 12 }}>
+      <button
+        onClick={handlePreview}
+        disabled={!validUrl || state === 'loading'}
+        style={{ fontSize: 12, padding: '3px 10px' }}
+      >
+        {state === 'loading' ? 'Loading…' : 'Preview'}
+      </button>
+      {state === 'error' && (
+        <div className="field-hint" style={{ color: 'var(--red)', marginTop: 6 }}>{error}</div>
       )}
-      {assetType === 'image' && (
-        <img
-          key={value}
-          src={value}
-          alt="preview"
-          style={{ maxHeight: 80, maxWidth: '100%', borderRadius: 4, marginTop: 6, objectFit: 'contain', background: 'var(--bg)', display: 'block' }}
-          onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
-          onLoad={e => { (e.target as HTMLImageElement).style.display = 'block'; }}
-        />
+      {state === 'done' && assetType === 'image' && (
+        <img src={cachedPath} alt="preview" style={{ maxHeight: 80, maxWidth: '100%', borderRadius: 4, marginTop: 6, objectFit: 'contain', display: 'block' }} />
       )}
-      {assetType === 'sound' && <audio key={value} src={value} controls style={{ width: '100%', marginTop: 6 }} />}
-      {assetType === 'video' && (
-        <video key={value} src={value} controls style={{ maxWidth: '100%', maxHeight: 120, marginTop: 6, borderRadius: 4, display: 'block' }} />
+      {state === 'done' && assetType === 'sound' && (
+        <audio src={cachedPath} controls style={{ width: '100%', marginTop: 6 }} />
       )}
-    </>
+      {state === 'done' && assetType === 'video' && (
+        <video src={cachedPath} controls style={{ maxWidth: '100%', maxHeight: 120, marginTop: 6, borderRadius: 4, display: 'block' }} />
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/components/ReactionCard.tsx
+++ b/frontend/src/components/ReactionCard.tsx
@@ -15,6 +15,12 @@ const TRANSITION_OUT = ['', 'fade-out', 'bounce-out', 'scale-out', 'slide-right-
 
 const TEMPLATE_HINT = '{{username}}, {{display_name}}, {{count}}';
 
+const ALLOWED_EXTENSIONS = {
+  image: ['jpg', 'jpeg', 'png', 'gif'],
+  sound: ['mp3', 'm4a'],
+  video: ['mp4'],
+} as const;
+
 export function defaultReaction(type: Reaction['type']): Reaction {
   switch (type) {
     case 'chat_reply':   return { type: 'chat_reply', message: '' };
@@ -23,6 +29,22 @@ export function defaultReaction(type: Reaction['type']): Reaction {
     case 'sound':        return { type: 'sound', filename: '' };
     case 'video':        return { type: 'video', filename: '' };
   }
+}
+
+function getExt(value: string): string | null {
+  const clean = value.split('?')[0].split('#')[0];
+  const dot = clean.lastIndexOf('.');
+  return dot >= 0 ? clean.slice(dot + 1).toLowerCase() : null;
+}
+
+function validateAsset(value: string, type: keyof typeof ALLOWED_EXTENSIONS): string | null {
+  if (!value) return null;
+  if (!value.startsWith('http://') && !value.startsWith('https://')) return 'Must be a URL starting with http:// or https://';
+  const ext = getExt(value);
+  if (!ext) return 'Cannot determine file type from URL';
+  return (ALLOWED_EXTENSIONS[type] as readonly string[]).includes(ext)
+    ? null
+    : `Allowed types: ${ALLOWED_EXTENSIONS[type].join(', ')}`;
 }
 
 interface Props {
@@ -82,22 +104,14 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
 
       {reaction.type === 'image' && <>
         <div className="field">
-          <label>URL</label>
+          <label>URL OR FILENAME</label>
           <input
             value={reaction.url}
             onChange={e => onChange({ ...reaction, url: e.target.value })}
-            placeholder="lurk.png"
+            placeholder="https://example.com/image.png"
           />
+          <AssetValidation value={reaction.url} assetType="image" />
         </div>
-        {reaction.url && (
-          <img
-            src={`/assets/img/${reaction.url}`}
-            alt="preview"
-            style={{ maxHeight: 80, maxWidth: '100%', borderRadius: 4, marginBottom: 12, objectFit: 'contain', background: 'var(--bg)' }}
-            onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
-            onLoad={e => { (e.target as HTMLImageElement).style.display = 'block'; }}
-          />
-        )}
         <OffsetFields reaction={reaction} onChange={onChange} />
         <TransitionFields reaction={reaction} onChange={onChange} />
         <TimeoutField reaction={reaction} onChange={onChange} />
@@ -105,12 +119,13 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
 
       {reaction.type === 'sound' && <>
         <div className="field">
-          <label>FILENAME</label>
+          <label>URL OR FILENAME</label>
           <input
             value={reaction.filename}
             onChange={e => onChange({ ...reaction, filename: e.target.value })}
-            placeholder="sound.mp3"
+            placeholder="https://example.com/sound.mp3"
           />
+          <AssetValidation value={reaction.filename} assetType="sound" />
         </div>
         <div className="field" style={{ marginBottom: 0 }}>
           <label>VOLUME (0–1)</label>
@@ -125,12 +140,13 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
 
       {reaction.type === 'video' && <>
         <div className="field">
-          <label>FILENAME</label>
+          <label>URL OR FILENAME</label>
           <input
             value={reaction.filename}
             onChange={e => onChange({ ...reaction, filename: e.target.value })}
-            placeholder="video.mp4"
+            placeholder="https://example.com/clip.mp4"
           />
+          <AssetValidation value={reaction.filename} assetType="video" />
         </div>
         <OffsetFields reaction={reaction} onChange={onChange} />
         <TransitionFields reaction={reaction} onChange={onChange} />
@@ -138,6 +154,41 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
       </>}
     </div>
   );
+}
+
+function AssetValidation({ value, assetType }: { value: string; assetType: keyof typeof ALLOWED_EXTENSIONS }) {
+  if (!value) return null;
+  const error = validateAsset(value, assetType);
+  if (error) return <div className="field-hint" style={{ color: 'var(--red)' }}>{error}</div>;
+
+  if (assetType === 'image') {
+    return (
+      <img
+        src={value}
+        alt="preview"
+        style={{ maxHeight: 80, maxWidth: '100%', borderRadius: 4, marginTop: 6, objectFit: 'contain', background: 'var(--bg)', display: 'block' }}
+        onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+        onLoad={e => { (e.target as HTMLImageElement).style.display = 'block'; }}
+      />
+    );
+  }
+
+  if (assetType === 'sound') {
+    return <audio key={value} src={value} controls style={{ width: '100%', marginTop: 6 }} />;
+  }
+
+  if (assetType === 'video') {
+    return (
+      <video
+        key={value}
+        src={value}
+        controls
+        style={{ maxWidth: '100%', maxHeight: 120, marginTop: 6, borderRadius: 4, display: 'block' }}
+      />
+    );
+  }
+
+  return null;
 }
 
 type WithTransitions = { transition_in?: string; transition_out?: string };

--- a/frontend/src/components/ReactionCard.tsx
+++ b/frontend/src/components/ReactionCard.tsx
@@ -61,7 +61,7 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
   }
 
   return (
-    <div className="card" style={{ padding: 14, marginBottom: 10, position: 'relative' }}>
+    <div className="card" style={{ padding: 18, marginBottom: 14, position: 'relative' }}>
       <button
         onClick={onRemove}
         style={{ position: 'absolute', top: 10, right: 10, background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 16, lineHeight: 1 }}
@@ -217,13 +217,13 @@ function PreviewBox({ url, assetType }: { url: string; assetType: 'image' | 'sou
         <div className="field-hint" style={{ color: 'var(--red)', marginTop: 6 }}>{error}</div>
       )}
       {state === 'done' && assetType === 'image' && (
-        <img src={cachedPath} alt="preview" style={{ maxHeight: 80, maxWidth: '100%', borderRadius: 4, marginTop: 6, objectFit: 'contain', display: 'block' }} />
+        <img src={cachedPath} alt="preview" style={{ maxHeight: 200, maxWidth: '100%', borderRadius: 4, marginTop: 8, objectFit: 'contain', display: 'block' }} />
       )}
       {state === 'done' && assetType === 'sound' && (
-        <audio src={cachedPath} controls style={{ width: '100%', marginTop: 6 }} />
+        <audio src={cachedPath} controls style={{ width: '100%', marginTop: 8 }} />
       )}
       {state === 'done' && assetType === 'video' && (
-        <video src={cachedPath} controls style={{ maxWidth: '100%', maxHeight: 120, marginTop: 6, borderRadius: 4, display: 'block' }} />
+        <video src={cachedPath} controls style={{ maxWidth: '100%', maxHeight: 200, marginTop: 8, borderRadius: 4, display: 'block' }} />
       )}
     </div>
   );

--- a/frontend/src/components/ReactionCard.tsx
+++ b/frontend/src/components/ReactionCard.tsx
@@ -42,8 +42,16 @@ function convertGoogleUrl(value: string): string {
   return value;
 }
 
+function convertUrl(value: string): string {
+  return convertGoogleUrl(value).replace(/([?&])dl=0\b/, '$1dl=1');
+}
+
 function isGoogleUrl(value: string): boolean {
   return /drive\.google\.com|drive\.usercontent\.google\.com|photos\.google\.com/.test(value);
+}
+
+function wasDownloadConverted(value: string): boolean {
+  return /[?&]dl=1/.test(value);
 }
 
 interface Props {
@@ -106,7 +114,7 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
           <label>URL</label>
           <input
             value={reaction.url}
-            onChange={e => onChange({ ...reaction, url: convertGoogleUrl(e.target.value) })}
+            onChange={e => onChange({ ...reaction, url: convertUrl(e.target.value) })}
             placeholder="https://example.com/image.png"
           />
           <AssetValidation value={reaction.url} />
@@ -122,7 +130,7 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
           <label>URL</label>
           <input
             value={reaction.filename}
-            onChange={e => onChange({ ...reaction, filename: convertGoogleUrl(e.target.value) })}
+            onChange={e => onChange({ ...reaction, filename: convertUrl(e.target.value) })}
             placeholder="https://example.com/sound.mp3"
           />
           <AssetValidation value={reaction.filename} />
@@ -144,7 +152,7 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
           <label>URL</label>
           <input
             value={reaction.filename}
-            onChange={e => onChange({ ...reaction, filename: convertGoogleUrl(e.target.value) })}
+            onChange={e => onChange({ ...reaction, filename: convertUrl(e.target.value) })}
             placeholder="https://example.com/clip.mp4"
           />
           <AssetValidation value={reaction.filename} />
@@ -166,6 +174,13 @@ function AssetValidation({ value }: { value: string }) {
     return (
       <div className="field-hint" style={{ color: '#a970ff' }}>
         Your Google URL will be converted to a downloadable URL
+      </div>
+    );
+  }
+  if (wasDownloadConverted(value)) {
+    return (
+      <div className="field-hint" style={{ color: '#a970ff' }}>
+        URL updated to dl=1 to support direct downloading
       </div>
     );
   }

--- a/frontend/src/components/ReactionCard.tsx
+++ b/frontend/src/components/ReactionCard.tsx
@@ -34,16 +34,16 @@ function validateAsset(value: string): string | null {
 
 function convertGoogleUrl(value: string): string {
   const driveMatch = value.match(/drive\.google\.com\/file\/d\/([^/?#]+)/);
-  if (driveMatch) return `https://drive.google.com/uc?export=download&id=${driveMatch[1]}`;
+  if (driveMatch) return `https://drive.usercontent.google.com/download?id=${driveMatch[1]}&export=download&authuser=0`;
 
   const driveOpenMatch = value.match(/drive\.google\.com\/(?:open|uc)\?.*?[?&]id=([^&]+)/);
-  if (driveOpenMatch) return `https://drive.google.com/uc?export=download&id=${driveOpenMatch[1]}`;
+  if (driveOpenMatch) return `https://drive.usercontent.google.com/download?id=${driveOpenMatch[1]}&export=download&authuser=0`;
 
   return value;
 }
 
 function isGoogleUrl(value: string): boolean {
-  return /drive\.google\.com|photos\.google\.com/.test(value);
+  return /drive\.google\.com|drive\.usercontent\.google\.com|photos\.google\.com/.test(value);
 }
 
 interface Props {

--- a/frontend/src/components/ReactionCard.tsx
+++ b/frontend/src/components/ReactionCard.tsx
@@ -136,7 +136,7 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
           <AssetValidation value={reaction.filename} />
         </div>
         <PreviewBox key={reaction.filename} url={reaction.filename} assetType="sound" />
-        <div className="field" style={{ marginBottom: 0 }}>
+        <div className="field" style={{ marginBottom: 12 }}>
           <label>VOLUME (0–1)</label>
           <input
             type="number"
@@ -145,6 +145,7 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
             onChange={e => onChange({ ...reaction, volume: parseFloat(e.target.value) })}
           />
         </div>
+        <TrimFields reaction={reaction} onChange={onChange} />
       </>}
 
       {reaction.type === 'video' && <>
@@ -160,7 +161,7 @@ export default function ReactionCard({ reaction, usedTypes, onChange, onRemove }
         <PreviewBox key={reaction.filename} url={reaction.filename} assetType="video" />
         <OffsetFields reaction={reaction} onChange={onChange} />
         <TransitionFields reaction={reaction} onChange={onChange} />
-        <TimeoutField reaction={reaction} onChange={onChange} />
+        <TrimFields reaction={reaction} onChange={onChange} />
       </>}
     </div>
   );
@@ -247,6 +248,7 @@ function PreviewBox({ url, assetType }: { url: string; assetType: 'image' | 'sou
 type WithTransitions = { transition_in?: string; transition_out?: string };
 type WithTimeout     = { timeout?: string };
 type WithOffsets     = { offsetX?: number; offsetY?: number; offsetZ?: number };
+type WithTrim        = { startTime?: number; endTime?: number };
 
 function TransitionFields<T extends WithTransitions>({ reaction, onChange }: { reaction: T; onChange: (r: T) => void }) {
   return (
@@ -294,6 +296,34 @@ function OffsetFields<T extends WithOffsets>({ reaction, onChange }: { reaction:
           />
         </div>
       ))}
+    </div>
+  );
+}
+
+function TrimFields<T extends WithTrim>({ reaction, onChange }: { reaction: T; onChange: (r: T) => void }) {
+  const parse = (v: string) => (v === '' ? undefined : Math.max(0, parseFloat(v)));
+  return (
+    <div className="field-row" style={{ marginBottom: 0 }}>
+      <div className="field" style={{ marginBottom: 0 }}>
+        <label>START (s)</label>
+        <input
+          type="number"
+          min={0} step={0.1}
+          value={reaction.startTime ?? ''}
+          onChange={e => onChange({ ...reaction, startTime: parse(e.target.value) })}
+          placeholder="0"
+        />
+      </div>
+      <div className="field" style={{ marginBottom: 0 }}>
+        <label>END (s)</label>
+        <input
+          type="number"
+          min={0} step={0.1}
+          value={reaction.endTime ?? ''}
+          onChange={e => onChange({ ...reaction, endTime: parse(e.target.value) })}
+          placeholder="(end of clip)"
+        />
+      </div>
     </div>
   );
 }

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -460,6 +460,15 @@
                 }
 
                 if (this.currentDisplay) {
+                    // In-DOM media (videos) won't fire onended once removed, so they'd
+                    // leak into playingMedia and permanently gate queueing. Drop them here.
+                    this.playingMedia = this.playingMedia.filter(media => {
+                        if (media instanceof HTMLElement && this.currentDisplay.contains(media)) {
+                            media.pause();
+                            return false;
+                        }
+                        return true;
+                    });
                     this.currentDisplay.remove();
                     this.currentDisplay = null;
                 }

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -238,6 +238,27 @@
     </div>
 
     <script>
+        // Forward console output to the server for remote diagnostics.
+        // Runs immediately so errors during initialisation are captured.
+        (function () {
+            const _orig = { log: console.log, warn: console.warn, error: console.error };
+            ['log', 'warn', 'error'].forEach(level => {
+                console[level] = function (...args) {
+                    _orig[level].apply(console, args);
+                    const message = args.map(a => {
+                        if (a instanceof Error) return a.stack || a.message;
+                        try { return typeof a === 'object' ? JSON.stringify(a) : String(a); }
+                        catch { return String(a); }
+                    }).join(' ');
+                    fetch('/api/overlay-log', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ level, message }),
+                    }).catch(() => {});
+                };
+            });
+        })();
+
         class TwitchOverlay {
 
             playingMedia = [];

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -526,15 +526,14 @@
             parseTimeout(timeoutStr) {
                 if (!timeoutStr) return null;
 
-                // Parse timeout strings like "5s", "2000ms", "3000"
+                // Parse timeout strings like "5s", "2000ms". A bare number is seconds
+                // (the editor is seconds-based, e.g. "6s") — so "5" means 5s, not 5ms.
                 if (typeof timeoutStr === 'number') return timeoutStr;
                 if (typeof timeoutStr === 'string') {
-                    if (timeoutStr.endsWith('s')) {
-                        return parseFloat(timeoutStr) * 1000;
-                    } else if (timeoutStr.endsWith('ms')) {
+                    if (timeoutStr.endsWith('ms')) {
                         return parseFloat(timeoutStr);
                     } else {
-                        return parseFloat(timeoutStr);
+                        return parseFloat(timeoutStr) * 1000;
                     }
                 }
                 return null;

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -6,6 +6,40 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Twitch Command Overlay</title>
     <style>
+        #cache-indicator {
+            display: none;
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0, 0, 0, 0.82);
+            color: #fff;
+            padding: 12px 20px;
+            border-radius: 8px;
+            text-align: center;
+            min-width: 280px;
+            z-index: 9999;
+            font-family: sans-serif;
+            font-size: 13px;
+        }
+        #cache-indicator-bar-track {
+            background: #333;
+            border-radius: 4px;
+            height: 5px;
+            overflow: hidden;
+            margin: 8px 0 6px;
+        }
+        #cache-indicator-bar {
+            background: #9147ff;
+            height: 100%;
+            width: 0%;
+            transition: width 0.25s ease;
+        }
+        #cache-indicator-count {
+            color: #aaa;
+            font-size: 11px;
+        }
+
         body {
             margin: 0;
             padding: 0;
@@ -195,6 +229,13 @@
 
 <body>
     <div id="overlay-container"></div>
+    <div id="cache-indicator">
+        Assets are caching&hellip;
+        <div id="cache-indicator-bar-track">
+            <div id="cache-indicator-bar"></div>
+        </div>
+        <div id="cache-indicator-count"></div>
+    </div>
 
     <script>
         class TwitchOverlay {
@@ -277,12 +318,27 @@
                     case 'event':
                         this.displayEvent(data);
                         break;
+                    case 'cache_progress':
+                        this.updateCacheIndicator(data.current, data.total, data.done);
+                        break;
                     case 'clear':
                         this.clearDisplay();
                         break;
                     default:
                         console.log('Unknown message type:', data.type);
                 }
+            }
+
+            updateCacheIndicator(current, total, done) {
+                const indicator = document.getElementById('cache-indicator');
+                if (done) {
+                    indicator.style.display = 'none';
+                    return;
+                }
+                indicator.style.display = 'block';
+                const pct = total > 0 ? (current / total) * 100 : 0;
+                document.getElementById('cache-indicator-bar').style.width = pct + '%';
+                document.getElementById('cache-indicator-count').textContent = `${current} / ${total}`;
             }
 
             shouldQueue() {

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -261,15 +261,12 @@
 
         class TwitchOverlay {
 
-            playingMedia = [];
             queuedConfigs = [];
 
             constructor() {
                 this.ws = null;
                 this.overlayContainer = document.getElementById('overlay-container');
-                this.currentDisplay = null;
-                this.displayTimeout = null;
-                this._transitionOut = 'fade-out';
+                this.currentEvent = null;
                 this.reconnectAttempts = 0;
                 this.maxReconnectAttempts = 5;
                 this.reconnectDelay = 1000; // Start with 1 second
@@ -362,152 +359,168 @@
                 document.getElementById('cache-indicator-count').textContent = `${current} / ${total}`;
             }
 
-            shouldQueue() {
-                return this.currentDisplay !== null || this.playingMedia.length > 0;
-            }
-
             displayEvent(eventData) {
-                if (this.shouldQueue()) {
+                // One event on screen at a time; later events wait their turn.
+                if (this.currentEvent) {
                     this.queuedConfigs.push(eventData);
                     return;
                 }
 
-                this.clearDisplay();
-
                 const reactions = eventData.reactions || [];
-                const displayElement = document.createElement('div');
-                displayElement.className = 'command-output';
-                let hasVisual = false;
-                let transitionOut = 'fade-out';
-                let timeout = null;
+                const container = document.createElement('div');
+                container.className = 'command-output';
+                this.overlayContainer.appendChild(container);
+
+                const event = { container, pending: 0, instances: [] };
+                this.currentEvent = event;
 
                 for (const reaction of reactions) {
                     switch (reaction.type) {
-                        case 'sound':
-                            this.playSound(reaction.filename, reaction.volume);
-                            break;
-                        case 'image': {
-                            const img = document.createElement('img');
-                            img.className = 'command-image';
-                            img.src = reaction.url;
-                            img.alt = eventData.event_name || 'Event image';
-                            if (reaction.transition_in) img.classList.add(reaction.transition_in);
-                            img.onerror = () => console.warn(`Image not found: ${reaction.url}`);
-                            displayElement.appendChild(img);
-                            if (reaction.transition_out) transitionOut = reaction.transition_out;
-                            if (reaction.timeout && timeout === null) timeout = this.parseTimeout(reaction.timeout);
-                            hasVisual = true;
-                            break;
-                        }
-                        case 'video': {
-                            const video = document.createElement('video');
-                            video.className = 'command-video';
-                            video.src = reaction.filename;
-                            video.autoplay = true;
-                            video.muted = true;
-                            video.loop = false;
-                            video.controls = false;
-                            if (reaction.transition_in) video.classList.add(reaction.transition_in);
-                            video.onerror = () => console.warn(`Video not found: ${reaction.filename}`);
-                            video.onloadeddata = () => this.playingMedia.push(video);
-                            video.onended = () => this.onMediaEnded(video, 'video', reaction.filename);
-                            displayElement.appendChild(video);
-                            if (reaction.transition_out) transitionOut = reaction.transition_out;
-                            if (reaction.timeout && timeout === null) timeout = this.parseTimeout(reaction.timeout);
-                            hasVisual = true;
-                            break;
-                        }
-                        case 'overlay_text': {
-                            const textDiv = document.createElement('div');
-                            textDiv.className = 'command-text';
-                            textDiv.textContent = reaction.text;
-                            if (reaction.transition_in) textDiv.classList.add(reaction.transition_in);
-                            displayElement.appendChild(textDiv);
-                            if (reaction.transition_out) transitionOut = reaction.transition_out;
-                            if (reaction.timeout && timeout === null) timeout = this.parseTimeout(reaction.timeout);
-                            hasVisual = true;
-                            break;
-                        }
+                        case 'sound':       this.spawnSound(event, reaction); break;
+                        case 'image':       this.spawnImage(event, reaction); break;
+                        case 'video':       this.spawnVideo(event, reaction); break;
+                        case 'overlay_text': this.spawnText(event, reaction); break;
                     }
                 }
 
-                if (hasVisual) {
-                    this.overlayContainer.appendChild(displayElement);
-                    this.currentDisplay = displayElement;
-                    this._transitionOut = transitionOut;
-                    this.displayTimeout = setTimeout(() => {
-                        this.hideDisplay(this._transitionOut);
-                    }, timeout !== null ? timeout : 5000);
-                }
+                // Nothing renderable (e.g. only a chat reply) — release immediately.
+                if (event.pending === 0) this.finishEvent(event);
             }
 
-            hideDisplay(transitionOut = 'fade-out') {
-                if (this.currentDisplay) {
-                    // Clear any existing classes and add exit transition
-                    this.currentDisplay.className = 'command-output ' + transitionOut;
+            // Each reaction gets an independent lifecycle: its own timers, its own
+            // transition-out, its own removal. The event finishes only once every
+            // reaction has completed, which is what advances the queue.
+            makeInstance(event) {
+                const instance = { el: null, media: null, timers: [], done: false, hiding: false };
+                event.instances.push(instance);
+                event.pending++;
 
-                    // Remove element after transition
-                    setTimeout(() => {
-                        this.clearDisplay();
-                    }, 500); // Match animation duration
-                }
+                instance.finalize = () => {
+                    if (instance.done) return;
+                    instance.done = true;
+                    instance.timers.forEach(clearTimeout);
+                    instance.timers = [];
+                    if (instance.el && instance.el.parentNode) instance.el.remove();
+                    this.reactionComplete(event);
+                };
+
+                instance.hide = (transitionOut) => {
+                    if (instance.done || instance.hiding) return;
+                    instance.hiding = true;
+                    if (instance.el && transitionOut) instance.el.classList.add(transitionOut);
+                    // Let the exit animation play before the element is removed.
+                    instance.timers.push(setTimeout(() => instance.finalize(), 500));
+                };
+
+                return instance;
             }
 
-            clearDisplay() {
-                if (this.displayTimeout) {
-                    clearTimeout(this.displayTimeout);
-                    this.displayTimeout = null;
-                }
-
-                if (this.currentDisplay) {
-                    // In-DOM media (videos) won't fire onended once removed, so they'd
-                    // leak into playingMedia and permanently gate queueing. Drop them here.
-                    this.playingMedia = this.playingMedia.filter(media => {
-                        if (media instanceof HTMLElement && this.currentDisplay.contains(media)) {
-                            media.pause();
-                            return false;
-                        }
-                        return true;
-                    });
-                    this.currentDisplay.remove();
-                    this.currentDisplay = null;
-                }
+            spawnImage(event, reaction) {
+                const instance = this.makeInstance(event);
+                const img = document.createElement('img');
+                img.className = 'command-image';
+                img.src = reaction.url;
+                img.alt = 'Event image';
+                if (reaction.transition_in) img.classList.add(reaction.transition_in);
+                img.onerror = () => console.warn(`Image not found: ${reaction.url}`);
+                event.container.appendChild(img);
+                instance.el = img;
+                const timeoutMs = this.parseTimeout(reaction.timeout) ?? 5000;
+                instance.timers.push(setTimeout(() => instance.hide(reaction.transition_out || 'fade-out'), timeoutMs));
             }
 
-            playSound(soundFile, volume) {
+            spawnText(event, reaction) {
+                const instance = this.makeInstance(event);
+                const textDiv = document.createElement('div');
+                textDiv.className = 'command-text';
+                textDiv.textContent = reaction.text;
+                if (reaction.transition_in) textDiv.classList.add(reaction.transition_in);
+                event.container.appendChild(textDiv);
+                instance.el = textDiv;
+                const timeoutMs = this.parseTimeout(reaction.timeout) ?? 5000;
+                instance.timers.push(setTimeout(() => instance.hide(reaction.transition_out || 'fade-out'), timeoutMs));
+            }
+
+            spawnVideo(event, reaction) {
+                const instance = this.makeInstance(event);
+                const transitionOut = reaction.transition_out || 'fade-out';
+                const video = document.createElement('video');
+                video.className = 'command-video';
+                video.src = reaction.filename;
+                video.muted = true;
+                video.loop = false;
+                video.controls = false;
+                if (reaction.transition_in) video.classList.add(reaction.transition_in);
+                video.onerror = () => { console.warn(`Video not found: ${reaction.filename}`); instance.hide(transitionOut); };
+                video.onloadedmetadata = () => {
+                    if (reaction.startTime) video.currentTime = reaction.startTime;
+                    video.play().catch(err => console.warn(`Could not play video: ${reaction.filename}`, err));
+                };
+                video.ontimeupdate = () => {
+                    if (reaction.endTime != null && video.currentTime >= reaction.endTime) {
+                        video.pause();
+                        instance.hide(transitionOut);
+                    }
+                };
+                // No timeout for video: it plays until its natural end or endTime.
+                video.onended = () => instance.hide(transitionOut);
+                event.container.appendChild(video);
+                instance.el = video;
+                instance.media = video;
+            }
+
+            spawnSound(event, reaction) {
+                const instance = this.makeInstance(event);
                 try {
-                    const audio = new Audio(soundFile);
-                    audio.volume = volume !== undefined ? volume : 0.5; // Use specified volume or default to 0.5
-
-                    // Track audio in playing media
-                    this.playingMedia.push(audio);
-                    
-                    // Handle audio end
-                    audio.onended = () => {
-                        console.log(`Audio ended: ${soundFile}`);
-                        this.onMediaEnded(audio, 'audio', soundFile);
-                    };
-                    
+                    const audio = new Audio(reaction.filename);
+                    audio.volume = reaction.volume !== undefined ? reaction.volume : 0.5;
+                    instance.media = audio;
+                    if (reaction.startTime) {
+                        audio.onloadedmetadata = () => { audio.currentTime = reaction.startTime; };
+                    }
+                    if (reaction.endTime != null) {
+                        audio.ontimeupdate = () => {
+                            if (audio.currentTime >= reaction.endTime) { audio.pause(); instance.finalize(); }
+                        };
+                    }
+                    audio.onended = () => instance.finalize();
                     audio.play().catch(error => {
-                        console.warn(`Could not play sound: ${soundFile}`, error);
-                        // Remove from playing media if play failed
-                        this.playingMedia = this.playingMedia.filter(media => media !== audio);
+                        console.warn(`Could not play sound: ${reaction.filename}`, error);
+                        instance.finalize();
                     });
                 } catch (error) {
-                    console.warn(`Sound file not found: ${soundFile}`, error);
+                    console.warn(`Sound file not found: ${reaction.filename}`, error);
+                    instance.finalize();
                 }
             }
 
-            onMediaEnded(mediaElement, mediaType, fileName) {
-                console.log(`${mediaType} ended: ${fileName}`);
-                
-                // Remove from playing media array
-                this.playingMedia = this.playingMedia.filter(media => media !== mediaElement);
-                
+            reactionComplete(event) {
+                event.pending--;
+                if (event.pending <= 0) this.finishEvent(event);
+            }
+
+            finishEvent(event) {
+                // Guard against stale callbacks firing after a hard clear.
+                if (this.currentEvent !== event) return;
+                if (event.container && event.container.parentNode) event.container.remove();
+                this.currentEvent = null;
                 if (this.queuedConfigs.length > 0) {
-                    const nextConfig = this.queuedConfigs.shift();
-                    this.displayEvent(nextConfig);
+                    this.displayEvent(this.queuedConfigs.shift());
                 }
+            }
+
+            // Hard reset (server 'clear' message): tear down the active event and
+            // drop anything queued behind it.
+            clearDisplay() {
+                this.queuedConfigs = [];
+                const event = this.currentEvent;
+                if (!event) return;
+                this.currentEvent = null;
+                for (const instance of event.instances) {
+                    instance.timers.forEach(clearTimeout);
+                    if (instance.media) { try { instance.media.pause(); } catch {} }
+                }
+                if (event.container && event.container.parentNode) event.container.remove();
             }
 
             parseTimeout(timeoutStr) {

--- a/overlay/index.html
+++ b/overlay/index.html
@@ -312,7 +312,7 @@
                         case 'image': {
                             const img = document.createElement('img');
                             img.className = 'command-image';
-                            img.src = `/assets/img/${reaction.url}`;
+                            img.src = reaction.url;
                             img.alt = eventData.event_name || 'Event image';
                             if (reaction.transition_in) img.classList.add(reaction.transition_in);
                             img.onerror = () => console.warn(`Image not found: ${reaction.url}`);
@@ -325,7 +325,7 @@
                         case 'video': {
                             const video = document.createElement('video');
                             video.className = 'command-video';
-                            video.src = `/assets/video/${reaction.filename}`;
+                            video.src = reaction.filename;
                             video.autoplay = true;
                             video.muted = true;
                             video.loop = false;
@@ -390,7 +390,7 @@
 
             playSound(soundFile, volume) {
                 try {
-                    const audio = new Audio(`/assets/audio/${soundFile}`);
+                    const audio = new Audio(soundFile);
                     audio.volume = volume !== undefined ? volume : 0.5; // Use specified volume or default to 0.5
 
                     // Track audio in playing media

--- a/tests/base/Handler.test.ts
+++ b/tests/base/Handler.test.ts
@@ -6,6 +6,14 @@ vi.mock('../../backend/src/utils/Logger.js', () => ({
     default: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), log: vi.fn() },
 }))
 
+vi.mock('../../backend/src/services/AssetCacheService.js', () => ({
+    default: {
+        resolve: vi.fn((value: string) =>
+            value.startsWith('http') ? `/cache/test/${value.split('/').pop() ?? ''}` : ''
+        ),
+    },
+}))
+
 const baseConfig: EventConfig = {
     event_name: 'test_event',
     event_type: 'chat_command',
@@ -74,13 +82,13 @@ describe('Handler.executeConfig', () => {
     it('broadcasts an overlay event when an image reaction is present', async () => {
         await handler.executeConfig({
             ...baseConfig,
-            reactions: [{ type: 'image', url: 'alert.png' }],
+            reactions: [{ type: 'image', url: 'https://example.com/alert.png' }],
         }, {})
         expect(mockOverlay.broadcast).toHaveBeenCalledWith(expect.objectContaining({
             type: 'event',
             event_name: 'test_event',
             reactions: expect.arrayContaining([
-                expect.objectContaining({ type: 'image', url: 'alert.png' })
+                expect.objectContaining({ type: 'image', url: '/cache/test/alert.png' })
             ]),
         }))
     })
@@ -88,7 +96,7 @@ describe('Handler.executeConfig', () => {
     it('broadcasts when a sound reaction is present', async () => {
         await handler.executeConfig({
             ...baseConfig,
-            reactions: [{ type: 'sound', filename: 'alert.mp3' }],
+            reactions: [{ type: 'sound', filename: 'https://example.com/alert.mp3' }],
         }, {})
         expect(mockOverlay.broadcast).toHaveBeenCalled()
     })
@@ -110,7 +118,7 @@ describe('Handler.executeConfig', () => {
         const h = new Handler(mockTwitchClient, null)
         await h.executeConfig({
             ...baseConfig,
-            reactions: [{ type: 'image', url: 'alert.png' }],
+            reactions: [{ type: 'image', url: 'https://example.com/alert.png' }],
         }, {})
         expect(mockOverlay.broadcast).not.toHaveBeenCalled()
     })
@@ -119,7 +127,7 @@ describe('Handler.executeConfig', () => {
         await handler.executeConfig({
             ...baseConfig,
             reactions: [
-                { type: 'image', url: 'x.png' },
+                { type: 'image', url: 'https://example.com/x.png' },
                 { type: 'overlay_text', text: '{{username}} arrived!' },
             ],
         }, { username: 'Eve' })
@@ -135,8 +143,8 @@ describe('Handler.executeConfig', () => {
             ...baseConfig,
             reactions: [
                 { type: 'chat_reply', message: 'hi' },
-                { type: 'image', url: 'img.png' },
-                { type: 'sound', filename: 'snd.mp3' },
+                { type: 'image', url: 'https://example.com/img.png' },
+                { type: 'sound', filename: 'https://example.com/snd.mp3' },
             ],
         }, {})
         expect(mockOverlay.broadcast).toHaveBeenCalledTimes(1)
@@ -163,7 +171,7 @@ describe('Handler.setTwitchClient / setOverlayBroadcasterService', () => {
         handler.setOverlayBroadcasterService(overlay)
         await handler.executeConfig({
             ...baseConfig,
-            reactions: [{ type: 'image', url: 'x.png' }],
+            reactions: [{ type: 'image', url: 'https://example.com/x.png' }],
         }, {})
         expect(overlay.broadcast).toHaveBeenCalled()
     })

--- a/tests/services/AssetCacheService.test.ts
+++ b/tests/services/AssetCacheService.test.ts
@@ -24,9 +24,10 @@ function makeConfig(reactions: EventConfig['reactions']): EventConfig {
     return { event_name: 'test', event_type: 'follow', reactions };
 }
 
-function mockResponse(mimeType: string) {
+function mockResponse(mimeType: string, url = '') {
     return {
         ok: true,
+        url,
         headers: { get: (h: string) => h === 'content-type' ? mimeType : null },
         arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
     };
@@ -223,8 +224,13 @@ describe('AssetCacheService', () => {
         });
 
         it('throws on HTTP error', async () => {
-            mockFetch.mockResolvedValue({ ok: false, status: 404, headers: { get: () => null }, arrayBuffer: vi.fn() });
+            mockFetch.mockResolvedValue({ ok: false, status: 404, url: '', headers: { get: () => null }, arrayBuffer: vi.fn() });
             await expect(service.previewUrl(imgUrl, 'image')).rejects.toThrow('HTTP 404');
+        });
+
+        it('throws a clear message when Google redirects to sign-in', async () => {
+            mockFetch.mockResolvedValue({ ...mockResponse('text/html'), url: 'https://accounts.google.com/ServiceLogin' });
+            await expect(service.previewUrl(imgUrl, 'image')).rejects.toThrow('requires sign-in');
         });
     });
 

--- a/tests/services/AssetCacheService.test.ts
+++ b/tests/services/AssetCacheService.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../backend/src/utils/Logger.js', () => ({
+    default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('fs/promises', () => ({
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('fs', () => ({
+    existsSync: vi.fn().mockReturnValue(true),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { AssetCacheService, isExternalUrl, extractExtension, extractAssetUrls } from '../../backend/src/services/AssetCacheService.js';
+import type { EventConfig } from '../../backend/src/types.js';
+
+function makeConfig(reactions: EventConfig['reactions']): EventConfig {
+    return { event_name: 'test', event_type: 'follow', reactions };
+}
+
+describe('isExternalUrl', () => {
+    it('returns true for https URLs', () => {
+        expect(isExternalUrl('https://example.com/img.png')).toBe(true);
+    });
+
+    it('returns true for http URLs', () => {
+        expect(isExternalUrl('http://example.com/img.png')).toBe(true);
+    });
+
+    it('returns false for local filenames', () => {
+        expect(isExternalUrl('lurk.png')).toBe(false);
+    });
+});
+
+describe('extractExtension', () => {
+    it('extracts extension from plain filename', () => {
+        expect(extractExtension('image.png')).toBe('png');
+    });
+
+    it('extracts extension from URL ignoring query string', () => {
+        expect(extractExtension('https://example.com/file.jpg?raw=1')).toBe('jpg');
+    });
+
+    it('returns null when no extension', () => {
+        expect(extractExtension('noext')).toBeNull();
+    });
+
+    it('lowercases extension', () => {
+        expect(extractExtension('FILE.PNG')).toBe('png');
+    });
+});
+
+describe('extractAssetUrls', () => {
+    it('finds external image URLs', () => {
+        const configs = [makeConfig([{ type: 'image', url: 'https://example.com/img.png' }])];
+        const results = extractAssetUrls(configs);
+        expect(results).toHaveLength(1);
+        expect(results[0]).toEqual({ url: 'https://example.com/img.png', assetType: 'image' });
+    });
+
+    it('finds external sound URLs', () => {
+        const configs = [makeConfig([{ type: 'sound', filename: 'https://example.com/sound.mp3' }])];
+        const results = extractAssetUrls(configs);
+        expect(results[0]).toEqual({ url: 'https://example.com/sound.mp3', assetType: 'sound' });
+    });
+
+    it('finds external video URLs', () => {
+        const configs = [makeConfig([{ type: 'video', filename: 'https://example.com/clip.mp4' }])];
+        const results = extractAssetUrls(configs);
+        expect(results[0]).toEqual({ url: 'https://example.com/clip.mp4', assetType: 'video' });
+    });
+
+    it('skips local filenames', () => {
+        const configs = [makeConfig([{ type: 'image', url: 'local.png' }])];
+        expect(extractAssetUrls(configs)).toHaveLength(0);
+    });
+
+    it('deduplicates identical URLs across configs', () => {
+        const url = 'https://example.com/img.png';
+        const configs = [
+            makeConfig([{ type: 'image', url }]),
+            makeConfig([{ type: 'image', url }]),
+        ];
+        expect(extractAssetUrls(configs)).toHaveLength(1);
+    });
+});
+
+describe('AssetCacheService', () => {
+    let service: AssetCacheService;
+    const configs: EventConfig[] = [
+        makeConfig([{ type: 'image', url: 'https://example.com/img.png' }]),
+    ];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        service = new AssetCacheService();
+
+        mockFetch.mockResolvedValue({
+            ok: true,
+            arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('resolve', () => {
+        it('returns empty string for local filenames', () => {
+            expect(service.resolve('lurk.png', 'image')).toBe('');
+        });
+
+        it('returns empty string when state is not ready', () => {
+            expect(service.resolve('https://example.com/img.png', 'image')).toBe('');
+        });
+
+        it('returns cached path when state is ready', async () => {
+            await service.ensureReady(configs);
+            const result = service.resolve('https://example.com/img.png', 'image');
+            expect(result).toMatch(/^\/cache\/[a-f0-9]+\/img\/[a-f0-9]+\.png$/);
+        });
+
+        it('returns same cached path for same URL', async () => {
+            await service.ensureReady(configs);
+            const url = 'https://example.com/img.png';
+            expect(service.resolve(url, 'image')).toBe(service.resolve(url, 'image'));
+        });
+    });
+
+    describe('ensureReady', () => {
+        it('downloads assets and sets state to ready', async () => {
+            await service.ensureReady(configs);
+            const { writeFile } = await import('fs/promises');
+            expect(writeFile).toHaveBeenCalled();
+        });
+
+        it('skips download on second call when already ready', async () => {
+            await service.ensureReady(configs);
+            const { writeFile } = await import('fs/promises');
+            const callCount = vi.mocked(writeFile).mock.calls.length;
+
+            await service.ensureReady(configs);
+            expect(vi.mocked(writeFile).mock.calls.length).toBe(callCount);
+        });
+
+        it('skips unsupported extensions', async () => {
+            const badConfigs = [makeConfig([{ type: 'image', url: 'https://example.com/file.bmp' }])];
+            await service.ensureReady(badConfigs);
+            const { writeFile } = await import('fs/promises');
+            expect(writeFile).not.toHaveBeenCalled();
+        });
+
+        it('still returns cached path when individual download fails (browser handles 404)', async () => {
+            mockFetch.mockRejectedValue(new Error('Network error'));
+            await service.ensureReady(configs);
+            const result = service.resolve('https://example.com/img.png', 'image');
+            expect(result).toMatch(/^\/cache\/[a-f0-9]+\/img\/[a-f0-9]+\.png$/);
+        });
+    });
+
+    describe('connection tracking', () => {
+        it('cancels cleanup timer on reconnect', async () => {
+            service.onConnect();
+            service.onDisconnect();
+            service.onConnect();
+            await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+            const { rm } = await import('fs/promises');
+            expect(rm).not.toHaveBeenCalled();
+        });
+
+        it('triggers cleanup 1 hour after all connections close', async () => {
+            service.onConnect();
+            service.onDisconnect();
+            await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+            const { rm } = await import('fs/promises');
+            expect(rm).toHaveBeenCalled();
+        });
+
+        it('does not clean up while connections remain', async () => {
+            service.onConnect();
+            service.onConnect();
+            service.onDisconnect();
+            await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+            const { rm } = await import('fs/promises');
+            expect(rm).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/services/AssetCacheService.test.ts
+++ b/tests/services/AssetCacheService.test.ts
@@ -17,19 +17,23 @@ vi.mock('fs', () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-import { AssetCacheService, isExternalUrl, extractAssetUrls, MIME_TO_EXT } from '../../backend/src/services/AssetCacheService.js';
+import { AssetCacheService, isExternalUrl, extractAssetUrls, MIME_TO_EXT, resolveAssetMime } from '../../backend/src/services/AssetCacheService.js';
 import type { EventConfig } from '../../backend/src/types.js';
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+const GIF_BYTES = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x00, 0x00]);
 
 function makeConfig(reactions: EventConfig['reactions']): EventConfig {
     return { event_name: 'test', event_type: 'follow', reactions };
 }
 
-function mockResponse(mimeType: string, url = '') {
+function mockResponse(mimeType: string, url = '', bytes: Uint8Array = new Uint8Array(8)) {
     return {
         ok: true,
         url,
         headers: { get: (h: string) => h === 'content-type' ? mimeType : null },
-        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+        arrayBuffer: vi.fn().mockResolvedValue(bytes.buffer),
     };
 }
 
@@ -62,6 +66,36 @@ describe('MIME_TO_EXT', () => {
 
     it('maps video types', () => {
         expect(MIME_TO_EXT['video/mp4']).toBe('mp4');
+    });
+});
+
+describe('resolveAssetMime', () => {
+    const b = (bytes: Uint8Array) => Buffer.from(bytes);
+
+    it('trusts a known, specific Content-Type header', () => {
+        expect(resolveAssetMime('image/png', b(new Uint8Array(8)), 'https://x/y.bin')).toBe('image/png');
+    });
+
+    it('rejects a specific but unsupported Content-Type without falling back', () => {
+        expect(resolveAssetMime('image/bmp', b(PNG_BYTES), 'https://x/y.png')).toBeUndefined();
+    });
+
+    it('sniffs PNG magic bytes when the header is generic', () => {
+        expect(resolveAssetMime('application/binary', b(PNG_BYTES), 'https://x/file')).toBe('image/png');
+    });
+
+    it('sniffs JPEG and GIF magic bytes', () => {
+        expect(resolveAssetMime('application/octet-stream', b(JPEG_BYTES), 'https://x/file')).toBe('image/jpeg');
+        expect(resolveAssetMime('', b(GIF_BYTES), 'https://x/file')).toBe('image/gif');
+    });
+
+    it('falls back to the URL extension when bytes are unrecognized', () => {
+        expect(resolveAssetMime('application/binary', b(new Uint8Array(8)), 'https://www.dropbox.com/s/abc/lurk.png?dl=1')).toBe('image/png');
+        expect(resolveAssetMime('application/binary', b(new Uint8Array(8)), 'https://x/clip.mp4')).toBe('video/mp4');
+    });
+
+    it('returns undefined when generic with no usable bytes or extension', () => {
+        expect(resolveAssetMime('application/binary', b(new Uint8Array(8)), 'https://x/file')).toBeUndefined();
     });
 });
 
@@ -221,6 +255,19 @@ describe('AssetCacheService', () => {
         it('throws when MIME type does not match asset type', async () => {
             mockFetch.mockResolvedValue(mockResponse('video/mp4'));
             await expect(service.previewUrl(imgUrl, 'image')).rejects.toThrow('not valid for image');
+        });
+
+        it('caches a generic application/binary response by sniffing magic bytes', async () => {
+            mockFetch.mockResolvedValue(mockResponse('application/binary', '', PNG_BYTES));
+            const path = await service.previewUrl(imgUrl, 'image');
+            expect(path).toMatch(/^\/cache\/[a-f0-9]+\/img\/[a-f0-9]+\.png$/);
+        });
+
+        it('caches a generic response by URL extension when bytes are unrecognized', async () => {
+            const dropboxUrl = 'https://www.dropbox.com/scl/fi/abc/lurk.png?dl=1';
+            mockFetch.mockResolvedValue(mockResponse('application/binary', '', new Uint8Array(8)));
+            const path = await service.previewUrl(dropboxUrl, 'image');
+            expect(path).toMatch(/^\/cache\/[a-f0-9]+\/img\/[a-f0-9]+\.png$/);
         });
 
         it('throws on HTTP error', async () => {

--- a/tests/services/AssetCacheService.test.ts
+++ b/tests/services/AssetCacheService.test.ts
@@ -17,11 +17,19 @@ vi.mock('fs', () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-import { AssetCacheService, isExternalUrl, extractExtension, extractAssetUrls } from '../../backend/src/services/AssetCacheService.js';
+import { AssetCacheService, isExternalUrl, extractAssetUrls, MIME_TO_EXT } from '../../backend/src/services/AssetCacheService.js';
 import type { EventConfig } from '../../backend/src/types.js';
 
 function makeConfig(reactions: EventConfig['reactions']): EventConfig {
     return { event_name: 'test', event_type: 'follow', reactions };
+}
+
+function mockResponse(mimeType: string) {
+    return {
+        ok: true,
+        headers: { get: (h: string) => h === 'content-type' ? mimeType : null },
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+    };
 }
 
 describe('isExternalUrl', () => {
@@ -38,21 +46,21 @@ describe('isExternalUrl', () => {
     });
 });
 
-describe('extractExtension', () => {
-    it('extracts extension from plain filename', () => {
-        expect(extractExtension('image.png')).toBe('png');
+describe('MIME_TO_EXT', () => {
+    it('maps image types', () => {
+        expect(MIME_TO_EXT['image/jpeg']).toBe('jpg');
+        expect(MIME_TO_EXT['image/png']).toBe('png');
+        expect(MIME_TO_EXT['image/gif']).toBe('gif');
     });
 
-    it('extracts extension from URL ignoring query string', () => {
-        expect(extractExtension('https://example.com/file.jpg?raw=1')).toBe('jpg');
+    it('maps audio types', () => {
+        expect(MIME_TO_EXT['audio/mpeg']).toBe('mp3');
+        expect(MIME_TO_EXT['audio/mp4']).toBe('m4a');
+        expect(MIME_TO_EXT['audio/x-m4a']).toBe('m4a');
     });
 
-    it('returns null when no extension', () => {
-        expect(extractExtension('noext')).toBeNull();
-    });
-
-    it('lowercases extension', () => {
-        expect(extractExtension('FILE.PNG')).toBe('png');
+    it('maps video types', () => {
+        expect(MIME_TO_EXT['video/mp4']).toBe('mp4');
     });
 });
 
@@ -66,14 +74,12 @@ describe('extractAssetUrls', () => {
 
     it('finds external sound URLs', () => {
         const configs = [makeConfig([{ type: 'sound', filename: 'https://example.com/sound.mp3' }])];
-        const results = extractAssetUrls(configs);
-        expect(results[0]).toEqual({ url: 'https://example.com/sound.mp3', assetType: 'sound' });
+        expect(extractAssetUrls(configs)[0]).toEqual({ url: 'https://example.com/sound.mp3', assetType: 'sound' });
     });
 
     it('finds external video URLs', () => {
         const configs = [makeConfig([{ type: 'video', filename: 'https://example.com/clip.mp4' }])];
-        const results = extractAssetUrls(configs);
-        expect(results[0]).toEqual({ url: 'https://example.com/clip.mp4', assetType: 'video' });
+        expect(extractAssetUrls(configs)[0]).toEqual({ url: 'https://example.com/clip.mp4', assetType: 'video' });
     });
 
     it('skips local filenames', () => {
@@ -93,19 +99,14 @@ describe('extractAssetUrls', () => {
 
 describe('AssetCacheService', () => {
     let service: AssetCacheService;
-    const configs: EventConfig[] = [
-        makeConfig([{ type: 'image', url: 'https://example.com/img.png' }]),
-    ];
+    const imgUrl = 'https://example.com/img.png';
+    const configs: EventConfig[] = [makeConfig([{ type: 'image', url: imgUrl }])];
 
     beforeEach(() => {
         vi.clearAllMocks();
         vi.useFakeTimers();
         service = new AssetCacheService();
-
-        mockFetch.mockResolvedValue({
-            ok: true,
-            arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
-        });
+        mockFetch.mockResolvedValue(mockResponse('image/png'));
     });
 
     afterEach(() => {
@@ -118,50 +119,60 @@ describe('AssetCacheService', () => {
         });
 
         it('returns empty string when state is not ready', () => {
-            expect(service.resolve('https://example.com/img.png', 'image')).toBe('');
+            expect(service.resolve(imgUrl, 'image')).toBe('');
         });
 
-        it('returns cached path when state is ready', async () => {
+        it('returns cached path after successful download', async () => {
             await service.ensureReady(configs);
-            const result = service.resolve('https://example.com/img.png', 'image');
+            const result = service.resolve(imgUrl, 'image');
             expect(result).toMatch(/^\/cache\/[a-f0-9]+\/img\/[a-f0-9]+\.png$/);
         });
 
         it('returns same cached path for same URL', async () => {
             await service.ensureReady(configs);
-            const url = 'https://example.com/img.png';
-            expect(service.resolve(url, 'image')).toBe(service.resolve(url, 'image'));
+            expect(service.resolve(imgUrl, 'image')).toBe(service.resolve(imgUrl, 'image'));
+        });
+
+        it('returns empty string when download failed for that URL', async () => {
+            mockFetch.mockRejectedValue(new Error('Network error'));
+            await service.ensureReady(configs);
+            expect(service.resolve(imgUrl, 'image')).toBe('');
         });
     });
 
     describe('ensureReady', () => {
-        it('downloads assets and sets state to ready', async () => {
+        it('downloads assets using MIME type from Content-Type header', async () => {
             await service.ensureReady(configs);
             const { writeFile } = await import('fs/promises');
             expect(writeFile).toHaveBeenCalled();
+        });
+
+        it('skips assets with unsupported MIME type', async () => {
+            mockFetch.mockResolvedValue(mockResponse('image/bmp'));
+            await service.ensureReady(configs);
+            const { writeFile } = await import('fs/promises');
+            expect(writeFile).not.toHaveBeenCalled();
+        });
+
+        it('skips assets with wrong MIME type for reaction type', async () => {
+            const badConfigs = [makeConfig([{ type: 'image', url: imgUrl }])];
+            mockFetch.mockResolvedValue(mockResponse('video/mp4'));
+            await service.ensureReady(badConfigs);
+            const { writeFile } = await import('fs/promises');
+            expect(writeFile).not.toHaveBeenCalled();
         });
 
         it('skips download on second call when already ready', async () => {
             await service.ensureReady(configs);
             const { writeFile } = await import('fs/promises');
             const callCount = vi.mocked(writeFile).mock.calls.length;
-
             await service.ensureReady(configs);
             expect(vi.mocked(writeFile).mock.calls.length).toBe(callCount);
         });
 
-        it('skips unsupported extensions', async () => {
-            const badConfigs = [makeConfig([{ type: 'image', url: 'https://example.com/file.bmp' }])];
-            await service.ensureReady(badConfigs);
-            const { writeFile } = await import('fs/promises');
-            expect(writeFile).not.toHaveBeenCalled();
-        });
-
-        it('still returns cached path when individual download fails (browser handles 404)', async () => {
+        it('handles individual download failures gracefully', async () => {
             mockFetch.mockRejectedValue(new Error('Network error'));
-            await service.ensureReady(configs);
-            const result = service.resolve('https://example.com/img.png', 'image');
-            expect(result).toMatch(/^\/cache\/[a-f0-9]+\/img\/[a-f0-9]+\.png$/);
+            await expect(service.ensureReady(configs)).resolves.not.toThrow();
         });
     });
 

--- a/tests/services/AssetCacheService.test.ts
+++ b/tests/services/AssetCacheService.test.ts
@@ -176,6 +176,58 @@ describe('AssetCacheService', () => {
         });
     });
 
+    describe('invalidate', () => {
+        it('resets state so ensureReady re-downloads on next call', async () => {
+            await service.ensureReady(configs);
+            service.invalidate();
+            vi.clearAllMocks();
+            await service.ensureReady(configs);
+            const { writeFile } = await import('fs/promises');
+            expect(writeFile).toHaveBeenCalled();
+        });
+
+        it('clears resolve results after invalidation', async () => {
+            await service.ensureReady(configs);
+            expect(service.resolve(imgUrl, 'image')).not.toBe('');
+            service.invalidate();
+            expect(service.resolve(imgUrl, 'image')).toBe('');
+        });
+    });
+
+    describe('previewUrl', () => {
+        it('downloads and returns a cached path', async () => {
+            const path = await service.previewUrl(imgUrl, 'image');
+            expect(path).toMatch(/^\/cache\/[a-f0-9]+\/img\/[a-f0-9]+\.png$/);
+        });
+
+        it('returns existing cached path without re-downloading', async () => {
+            await service.previewUrl(imgUrl, 'image');
+            const { writeFile } = await import('fs/promises');
+            const callsBefore = vi.mocked(writeFile).mock.calls.length;
+            await service.previewUrl(imgUrl, 'image');
+            expect(vi.mocked(writeFile).mock.calls.length).toBe(callsBefore);
+        });
+
+        it('throws for a local filename', async () => {
+            await expect(service.previewUrl('local.png', 'image')).rejects.toThrow('Must be an external URL');
+        });
+
+        it('throws for unsupported MIME type', async () => {
+            mockFetch.mockResolvedValue(mockResponse('image/bmp'));
+            await expect(service.previewUrl(imgUrl, 'image')).rejects.toThrow('Unsupported content type');
+        });
+
+        it('throws when MIME type does not match asset type', async () => {
+            mockFetch.mockResolvedValue(mockResponse('video/mp4'));
+            await expect(service.previewUrl(imgUrl, 'image')).rejects.toThrow('not valid for image');
+        });
+
+        it('throws on HTTP error', async () => {
+            mockFetch.mockResolvedValue({ ok: false, status: 404, headers: { get: () => null }, arrayBuffer: vi.fn() });
+            await expect(service.previewUrl(imgUrl, 'image')).rejects.toThrow('HTTP 404');
+        });
+    });
+
     describe('connection tracking', () => {
         it('cancels cleanup timer on reconnect', async () => {
             service.onConnect();


### PR DESCRIPTION
## Summary

- Adds `AssetCacheService` — downloads external (`http/https`) asset URLs to a local `cache/<channelHash>/` directory on overlay connect or dashboard load, subdivided by type (`img/`, `audio/`, `video/`)
- Handler resolves cached paths before broadcasting events to the overlay, so the overlay always works with local files
- Broadcasts `cache_progress` events to the overlay during initial download so a loading indicator can be shown
- Assets are cleaned up 1 hour after all overlay/dashboard connections drop

## Also included

- Asset preview in `ReactionCard` — fetches and caches assets server-side, renders inline preview (image/audio/video) in the editor
- Auto-converts Google Drive URLs (including auth redirect and confirmation page handling) and Dropbox `dl=0` → `dl=1`
- MIME sniffing for generic `content-type` responses
- `startTime` / `endTime` trim fields on video and sound reactions
- Per-element reaction lifecycle on overlay (each reaction manages its own DOM element and timers independently)
- Fix: overlay queue stall when a video element was removed before `ended` fired
- Fix: `parseTimeout` treating bare numbers as milliseconds instead of seconds
- Fix: overlay console output forwarded to server for remote diagnostics
- Re-caches assets automatically after event create/update

## Test plan

- [ ] Overlay connects → assets download to `cache/` before events fire
- [ ] Events with external image/sound/video URLs render correctly in OBS browser source
- [ ] Google Drive URLs convert and cache without auth redirects
- [ ] `cache_progress` indicator appears on overlay during initial cache
- [ ] Asset preview works in event editor for image, audio, and video
- [ ] Cache clears ~1 hour after all connections drop
- [ ] `startTime`/`endTime` trim respected on video and sound playback
- [ ] Existing tests pass (`npm test`)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)